### PR TITLE
Parallelize poll hot path; decouple expiry sweep

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -804,6 +804,31 @@ func (s *Store) RecordLookup(ctx context.Context, l LookupLog) error {
 	return err
 }
 
+func (s *Store) RecordLookupBatch(ctx context.Context, ls []LookupLog) error {
+	if len(ls) == 0 {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO lookup_log(provider, campground_id, start_date, end_date, checked_at, success, error_msg, campsite_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	for _, l := range ls {
+		if _, err := stmt.ExecContext(ctx, l.Provider, l.CampgroundID, l.StartDate, l.EndDate, l.CheckedAt, l.Success, l.ErrorMsg, l.CampsiteCount); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Store) RecordNotification(ctx context.Context, n Notification) error {
 	_, err := s.DB.ExecContext(ctx, `
 		INSERT INTO notifications(request_id, user_id, provider, campground_id, campsite_id, date, state, sent_at)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -77,6 +77,9 @@ func (m *Manager) Run(ctx context.Context) {
 	// Start the ad-hoc scrape processor
 	m.StartAdhocScrapeProcessor(ctx)
 
+	// Expire deactivation runs on its own cadence (used to run every poll cycle).
+	go m.runExpiryReaper(ctx)
+
 	// Start a goroutine for each provider
 	for _, providerName := range m.reg.GetProviderNames() {
 		go m.runProviderLoop(ctx, providerName)
@@ -84,6 +87,32 @@ func (m *Manager) Run(ctx context.Context) {
 
 	// Wait for context cancellation
 	<-ctx.Done()
+}
+
+const expiryReaperInterval = 5 * time.Minute
+
+// runExpiryReaper periodically deactivates schniff requests whose checkout date
+// has passed, and DMs the owning users. Decoupled from the hot poll loop so the
+// scan isn't wasted work every 10s.
+func (m *Manager) runExpiryReaper(ctx context.Context) {
+	t := time.NewTicker(expiryReaperInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			deactivated, err := m.store.DeactivateExpiredRequests(ctx)
+			if err != nil {
+				m.logger.Warn("expiry reaper: deactivate failed", slog.Any("err", err))
+				continue
+			}
+			if len(deactivated) > 0 {
+				m.logger.Info("expiry reaper deactivated requests", slog.Int("count", len(deactivated)))
+				m.notifyUsersOfDeactivatedRequests(ctx, deactivated)
+			}
+		}
+	}
 }
 
 const fastestPoll = 10 * time.Second
@@ -119,127 +148,184 @@ func (m *Manager) runProviderLoop(ctx context.Context, providerName string) {
 	}
 }
 
-// PollProvider performs one poll cycle for a specific provider and returns a summary
+// maxConcurrentCampgrounds caps the fan-out per poll cycle. Each goroutine
+// makes one or more HTTP fetches via the proxy pool, which coalesces them
+// into batches; the cap exists to bound memory + DB writer pressure, not to
+// throttle the upstream.
+const maxConcurrentCampgrounds = 32
+
+// PollProvider performs one poll cycle for a specific provider.
+//
+// Returns an error only if more than half of campground fetches failed in the
+// same cycle (treated as a global upstream problem worth backing off for).
+// Individual fetch errors are logged but do not abort the cycle.
 func (m *Manager) PollProvider(ctx context.Context, targetProvider string) error {
-	deactivatedRequests, err := m.store.DeactivateExpiredRequests(ctx)
-	if err != nil {
-		m.logger.Warn("failed to deactivate expired requests", slog.Any("err", err))
-		return err
-	}
-
-	if len(deactivatedRequests) > 0 {
-		m.logger.Info("deactivated expired requests", slog.Int("count", len(deactivatedRequests)))
-
-		// Send notification to each user about their deactivated requests
-		m.notifyUsersOfDeactivatedRequests(ctx, deactivatedRequests)
-	}
-
 	requests, err := m.store.ListActiveRequests(ctx)
 	if err != nil {
 		m.logger.Error("list requests failed", slog.Any("err", err))
 		return nil
 	}
 
-	// Filter requests for the target provider
 	var filteredRequests []db.SchniffRequest
 	for _, req := range requests {
 		if req.Provider == targetProvider {
 			filteredRequests = append(filteredRequests, req)
 		}
 	}
-
 	if len(filteredRequests) == 0 {
 		return nil
 	}
 
-	// dedupe by provider+campground, then provider decides how to bucket dates
 	datesByPC, _ := collectDatesByPC(filteredRequests)
+	if len(datesByPC) == 0 {
+		return nil
+	}
+
+	prov, ok := m.reg.Get(targetProvider)
+	if !ok {
+		return nil
+	}
+
+	type cgResult struct {
+		lookups []db.LookupLog
+		failed  bool
+	}
+	results := make(chan cgResult, len(datesByPC))
+	sem := make(chan struct{}, maxConcurrentCampgrounds)
+	var wg sync.WaitGroup
+
 	for k, datesSet := range datesByPC {
-		prov, ok := m.reg.Get(k.prov)
-		if !ok {
-			continue
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(k pc, datesSet map[time.Time]struct{}) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results <- m.pollOneCampground(ctx, prov, k, datesSet)
+		}(k, datesSet)
+	}
+	wg.Wait()
+	close(results)
+
+	var allLookups []db.LookupLog
+	var totalCG, failedCG int
+	for r := range results {
+		allLookups = append(allLookups, r.lookups...)
+		totalCG++
+		if r.failed {
+			failedCG++
 		}
-		// to sorted slice
-		dates := datesFromSet(datesSet)
-		// provider decides minimal set of requests
-		buckets := prov.PlanBuckets(dates)
-		// collect all states for this provider+campground across buckets to enable bundled notifications
-		var collectedStates []providers.CampsiteAvailability
-		for _, b := range buckets {
+	}
+
+	// One batched insert at end of cycle instead of N writes through the writer.
+	if len(allLookups) > 0 {
+		if err := m.executeDBOperation(func() error {
+			return m.store.RecordLookupBatch(ctx, allLookups)
+		}); err != nil {
+			m.logger.Warn("record lookup batch failed", slog.Any("err", err))
+		}
+	}
+
+	if err := m.ProcessNotificationsWithBatches(ctx, filteredRequests); err != nil {
+		m.logger.Warn("process notifications failed", slog.String("provider", targetProvider), slog.Any("err", err))
+	}
+
+	if totalCG > 0 && failedCG*2 > totalCG {
+		return fmt.Errorf("most campground fetches failed (%d/%d)", failedCG, totalCG)
+	}
+	return nil
+}
+
+// pollOneCampground handles one (provider, campground) — plans buckets,
+// fetches them in parallel, upserts the resulting state, and returns the
+// lookup log entries that the caller will batch-insert.
+func (m *Manager) pollOneCampground(ctx context.Context, prov providers.Provider, k pc, datesSet map[time.Time]struct{}) (out struct {
+	lookups []db.LookupLog
+	failed  bool
+}) {
+	dates := datesFromSet(datesSet)
+	buckets := prov.PlanBuckets(dates)
+	if len(buckets) == 0 {
+		return
+	}
+
+	type bucketResult struct {
+		bucket providers.DateRange
+		states []providers.CampsiteAvailability
+		err    error
+	}
+	bres := make([]bucketResult, len(buckets))
+	var bwg sync.WaitGroup
+	for i, b := range buckets {
+		bwg.Add(1)
+		go func(i int, b providers.DateRange) {
+			defer bwg.Done()
 			states, err := prov.FetchAvailability(ctx, k.cg, b.Start, b.End)
-			if err != nil {
-				// return an error straight away at first sign of api failing
-				return fmt.Errorf("failed to fetch availability: %w", err)
-			}
+			bres[i] = bucketResult{bucket: b, states: states, err: err}
+		}(i, b)
+	}
+	bwg.Wait()
 
-			// record lookup if no error
-			err = m.store.RecordLookup(ctx, db.LookupLog{
-				Provider:      k.prov,
-				CampgroundID:  k.cg,
-				StartDate:     b.Start,
-				EndDate:       b.End,
-				CheckedAt:     time.Now(),
-				Success:       true,
-				CampsiteCount: len(states),
-			})
-			if err != nil {
-				m.logger.Warn("record lookup failed", slog.Any("err", err))
-			}
-
-			if len(states) == 0 {
-				m.logger.Info("no states returned", slog.String("provider", k.prov), slog.String("campground", k.cg), slog.Time("start", b.Start), slog.Time("end", b.End))
-			}
-			// collect for later bundled change detection and notification
-			collectedStates = append(collectedStates, states...)
+	now := time.Now()
+	var collected []providers.CampsiteAvailability
+	bucketFails := 0
+	for _, r := range bres {
+		entry := db.LookupLog{
+			Provider:     k.prov,
+			CampgroundID: k.cg,
+			StartDate:    r.bucket.Start,
+			EndDate:      r.bucket.End,
+			CheckedAt:    now,
 		}
-
-		// Process all collected states for this provider+campground at once
-		if len(collectedStates) == 0 {
-			continue
-		}
-
-		// Convert to db format
-		batch := make([]db.CampsiteAvailability, 0, len(collectedStates))
-		now := time.Now()
-		for _, s := range collectedStates {
-			batch = append(batch, db.CampsiteAvailability{
-				Provider:     k.prov,
-				CampgroundID: k.cg,
-				CampsiteID:   s.ID,
-				Date:         s.Date,
-				Available:    s.Available,
-				LastChecked:  now,
-			})
-		}
-
-		// Upsert states
-		start := time.Now()
-		err := m.executeDBOperation(func() error {
-			return m.store.UpsertCampsiteAvailabilityBatch(ctx, batch)
-		})
-		if err != nil {
-			// only http errors need to fail the function.
-			m.logger.Error("upsert states failed", slog.Any("err", err))
-		} else {
-			m.logger.Info("persisted campsite states",
+		if r.err != nil {
+			m.logger.Warn("fetch availability failed",
 				slog.String("provider", k.prov),
 				slog.String("campground", k.cg),
-				slog.Int("count", len(batch)),
-				slog.Duration("duration_ms", time.Since(start)),
-			)
+				slog.Time("start", r.bucket.Start),
+				slog.Time("end", r.bucket.End),
+				slog.Any("err", r.err))
+			entry.Success = false
+			entry.ErrorMsg = r.err.Error()
+			bucketFails++
+		} else {
+			entry.Success = true
+			entry.CampsiteCount = len(r.states)
+			collected = append(collected, r.states...)
 		}
-
+		out.lookups = append(out.lookups, entry)
+	}
+	if bucketFails == len(buckets) {
+		out.failed = true
 	}
 
-	// After processing all states, check for notifications
-	if len(filteredRequests) > 0 {
-		err := m.ProcessNotificationsWithBatches(ctx, filteredRequests)
-		if err != nil {
-			m.logger.Warn("process notifications failed", slog.String("provider", targetProvider), slog.Any("err", err))
-		}
+	if len(collected) == 0 {
+		return
 	}
 
-	return nil
+	batch := make([]db.CampsiteAvailability, 0, len(collected))
+	for _, s := range collected {
+		batch = append(batch, db.CampsiteAvailability{
+			Provider:     k.prov,
+			CampgroundID: k.cg,
+			CampsiteID:   s.ID,
+			Date:         s.Date,
+			Available:    s.Available,
+			LastChecked:  now,
+		})
+	}
+	start := time.Now()
+	if err := m.executeDBOperation(func() error {
+		return m.store.UpsertCampsiteAvailabilityBatch(ctx, batch)
+	}); err != nil {
+		m.logger.Error("upsert states failed", slog.String("provider", k.prov), slog.String("campground", k.cg), slog.Any("err", err))
+	} else {
+		m.logger.Info("persisted campsite states",
+			slog.String("provider", k.prov),
+			slog.String("campground", k.cg),
+			slog.Int("count", len(batch)),
+			slog.Duration("duration_ms", time.Since(start)),
+		)
+	}
+	return
 }
 
 // normalizeDay returns t truncated to 00:00:00 UTC.

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/brensch/schniffer/internal/db"
@@ -42,8 +43,14 @@ func (m *Manager) ProcessNotificationsWithBatches(ctx context.Context, requests 
 	var notificationsToRecord []db.Notification
 	now := time.Now()
 
-	// Process each request independently
+	// Process each request independently. DM sends are I/O-bound and slow
+	// (~100-300ms each), so fan out with a bounded worker pool.
 	reqIndex := indexRequestsByID(requests)
+	const maxConcurrentDMs = 5
+	sem := make(chan struct{}, maxConcurrentDMs)
+	var nwg sync.WaitGroup
+	var nmu sync.Mutex
+
 	for requestID, changes := range changesByRequest {
 		req, ok := reqIndex[requestID]
 		if !ok {
@@ -58,38 +65,46 @@ func (m *Manager) ProcessNotificationsWithBatches(ctx context.Context, requests 
 			slog.Int("changes", len(changes)),
 		)
 
-		// Use the changes we already have. Only send if there is at least ONE newly-available change.
-		sent, sendErr := m.sendStateChangeNotification(ctx, req, changes)
-		if sendErr != nil {
-			m.logger.Warn("send state change notification failed",
-				slog.String("userID", req.UserID),
-				slog.Any("err", sendErr))
-		}
+		nwg.Add(1)
+		sem <- struct{}{}
+		go func(req db.SchniffRequest, changes []db.StateChangeForRequest) {
+			defer nwg.Done()
+			defer func() { <-sem }()
 
-		// Post a fun summary broadcast only when we actually sent a DM about availability.
-		if sent {
-			_, _ = m.notifier.ChannelMessageSend(m.summaryChannelID, nonsense.RandomSillyBroadcast(req.UserID))
-		}
-
-		// Record outgoing notifications for each change (both available and unavailable).
-		for _, c := range changes {
-			state := "available"
-			if !c.NewAvailable {
-				state = "unavailable"
+			sent, sendErr := m.sendStateChangeNotification(ctx, req, changes)
+			if sendErr != nil {
+				m.logger.Warn("send state change notification failed",
+					slog.String("userID", req.UserID),
+					slog.Any("err", sendErr))
 			}
-			notificationsToRecord = append(notificationsToRecord, db.Notification{
-				RequestID:     req.ID,
-				UserID:        req.UserID,
-				Provider:      c.Provider,
-				CampgroundID:  c.CampgroundID,
-				CampsiteID:    c.CampsiteID,
-				Date:          c.Date,
-				State:         state,
-				StateChangeID: &c.ID,
-				SentAt:        now,
-			})
-		}
+			if sent {
+				_, _ = m.notifier.ChannelMessageSend(m.summaryChannelID, nonsense.RandomSillyBroadcast(req.UserID))
+			}
+
+			local := make([]db.Notification, 0, len(changes))
+			for _, c := range changes {
+				state := "available"
+				if !c.NewAvailable {
+					state = "unavailable"
+				}
+				local = append(local, db.Notification{
+					RequestID:     req.ID,
+					UserID:        req.UserID,
+					Provider:      c.Provider,
+					CampgroundID:  c.CampgroundID,
+					CampsiteID:    c.CampsiteID,
+					Date:          c.Date,
+					State:         state,
+					StateChangeID: &c.ID,
+					SentAt:        now,
+				})
+			}
+			nmu.Lock()
+			notificationsToRecord = append(notificationsToRecord, local...)
+			nmu.Unlock()
+		}(req, changes)
 	}
+	nwg.Wait()
 
 	// Record all notifications (single DB call)
 	if len(notificationsToRecord) > 0 {

--- a/internal/manager/parallelism_test.go
+++ b/internal/manager/parallelism_test.go
@@ -1,0 +1,203 @@
+package manager
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/brensch/schniffer/internal/db"
+	"github.com/brensch/schniffer/internal/providers"
+)
+
+// fakeProvider records call timings and sleeps for a fixed duration per
+// FetchAvailability invocation so we can prove parallelism by wall time.
+type fakeProvider struct {
+	name      string
+	latency   time.Duration
+	inFlight  atomic.Int32
+	peak      atomic.Int32
+	callCount atomic.Int32
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) FetchAvailability(ctx context.Context, campgroundID string, start, end time.Time) ([]providers.CampsiteAvailability, error) {
+	n := f.inFlight.Add(1)
+	defer f.inFlight.Add(-1)
+	for {
+		p := f.peak.Load()
+		if n <= p || f.peak.CompareAndSwap(p, n) {
+			break
+		}
+	}
+	f.callCount.Add(1)
+	select {
+	case <-time.After(f.latency):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return nil, nil
+}
+func (f *fakeProvider) FetchAllCampgrounds(context.Context) ([]providers.CampgroundInfo, error) {
+	return nil, nil
+}
+func (f *fakeProvider) FetchCampsites(context.Context, string) ([]providers.CampsiteInfo, error) {
+	return nil, nil
+}
+func (f *fakeProvider) CampsiteURL(string, string) string  { return "" }
+func (f *fakeProvider) CampgroundURL(string) string        { return "" }
+func (f *fakeProvider) PlanBuckets(d []time.Time) []providers.DateRange {
+	if len(d) == 0 {
+		return nil
+	}
+	return []providers.DateRange{{Start: d[0], End: d[len(d)-1]}}
+}
+
+func newTestStore(t *testing.T) *db.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+	store, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestPollProviderCampgroundsRunConcurrently asserts that PollProvider fans
+// out FetchAvailability across many campgrounds concurrently rather than
+// running them serially. With 20 campgrounds each "taking" 100ms, a serial
+// implementation would take 2s; the parallel implementation should finish
+// in well under 500ms.
+func TestPollProviderCampgroundsRunConcurrently(t *testing.T) {
+	store := newTestStore(t)
+	const fakeLatency = 100 * time.Millisecond
+	const numCampgrounds = 20
+
+	prov := &fakeProvider{name: "fake", latency: fakeLatency}
+	reg := providers.NewRegistry()
+	reg.Register(prov.Name(), prov)
+
+	m := &Manager{
+		store:       store,
+		reg:         reg,
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dbWriteChan: make(chan dbWriteRequest, 100),
+	}
+	go m.dbWriter()
+
+	ctx := context.Background()
+	checkin := time.Now().Add(24 * time.Hour).UTC().Truncate(24 * time.Hour)
+	checkout := checkin.Add(48 * time.Hour)
+	for i := range numCampgrounds {
+		_, err := store.DB.ExecContext(ctx, `
+			INSERT INTO schniff_requests(user_id, provider, campground_id, checkin, checkout, active)
+			VALUES (?, ?, ?, ?, ?, 1)
+		`, "u1", prov.Name(), itoa(i), checkin, checkout)
+		if err != nil {
+			t.Fatalf("insert request: %v", err)
+		}
+	}
+
+	start := time.Now()
+	if err := m.PollProvider(ctx, prov.Name()); err != nil {
+		t.Fatalf("PollProvider: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	calls := prov.callCount.Load()
+	peak := prov.peak.Load()
+
+	if calls != int32(numCampgrounds) {
+		t.Errorf("expected %d FetchAvailability calls, got %d", numCampgrounds, calls)
+	}
+	if peak < 2 {
+		t.Errorf("expected peak concurrency > 1, got %d (loop is serial)", peak)
+	}
+	// A serial impl would take numCampgrounds * fakeLatency = 2s. Allow generous slack.
+	maxAllowed := 5 * fakeLatency
+	if elapsed > maxAllowed {
+		t.Errorf("PollProvider took %v with %d concurrent fakes at %v each; expected < %v",
+			elapsed, numCampgrounds, fakeLatency, maxAllowed)
+	}
+	t.Logf("PollProvider elapsed=%v peak_concurrency=%d calls=%d", elapsed, peak, calls)
+}
+
+// flakyProvider returns an error for the first call only; later calls succeed.
+type flakyProvider struct {
+	fakeProvider
+	failOnce atomic.Bool
+}
+
+func (f *flakyProvider) FetchAvailability(ctx context.Context, campgroundID string, start, end time.Time) ([]providers.CampsiteAvailability, error) {
+	if f.failOnce.CompareAndSwap(false, true) {
+		return nil, errFakeUpstream
+	}
+	return f.fakeProvider.FetchAvailability(ctx, campgroundID, start, end)
+}
+
+var errFakeUpstream = errSentinel("fake upstream broke")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
+
+// TestPollProviderContinuesPastErrors asserts that a single failed
+// FetchAvailability doesn't abort the rest of the cycle's campgrounds.
+func TestPollProviderContinuesPastErrors(t *testing.T) {
+	store := newTestStore(t)
+	const numCampgrounds = 10
+
+	prov := &flakyProvider{fakeProvider: fakeProvider{name: "flaky", latency: 20 * time.Millisecond}}
+	reg := providers.NewRegistry()
+	reg.Register(prov.Name(), prov)
+
+	m := &Manager{
+		store:       store,
+		reg:         reg,
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dbWriteChan: make(chan dbWriteRequest, 100),
+	}
+	go m.dbWriter()
+
+	ctx := context.Background()
+	checkin := time.Now().Add(24 * time.Hour).UTC().Truncate(24 * time.Hour)
+	checkout := checkin.Add(48 * time.Hour)
+	for i := range numCampgrounds {
+		_, err := store.DB.ExecContext(ctx, `
+			INSERT INTO schniff_requests(user_id, provider, campground_id, checkin, checkout, active)
+			VALUES (?, ?, ?, ?, ?, 1)
+		`, "u1", prov.Name(), itoa(i), checkin, checkout)
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	if err := m.PollProvider(ctx, prov.Name()); err != nil {
+		t.Fatalf("PollProvider should not return error for single failure: %v", err)
+	}
+	// 10 campgrounds, 1 failure expected, 9 successes — but the failed one's
+	// goroutine still attempted, so callCount on the embedded fakeProvider
+	// counts only successful calls (flaky bypasses the embedded path on failure).
+	if got := prov.callCount.Load(); got != numCampgrounds-1 {
+		t.Errorf("expected %d successful fetches, got %d", numCampgrounds-1, got)
+	}
+}
+
+// itoa is a tiny no-strconv helper for test ids — keeps the file dep-free.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [16]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
+}

--- a/internal/providers/recreation_gov.go
+++ b/internal/providers/recreation_gov.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/brensch/schniffer/internal/httpx"
@@ -50,61 +51,100 @@ type recGovResp struct {
 }
 
 // FetchAvailability fetches monthly availability pages between start and end (inclusive by month).
+// Months are fetched concurrently; the proxy pool batches concurrent calls into
+// a single outbound request, so this is cheap.
 func (r *RecreationGov) FetchAvailability(ctx context.Context, campgroundID string, start, end time.Time) ([]CampsiteAvailability, error) {
-	var out []CampsiteAvailability
+	type monthResult struct {
+		out []CampsiteAvailability
+		err error
+	}
+	var months []time.Time
 	cur := time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, time.UTC)
 	endMonth := time.Date(end.Year(), end.Month(), 1, 0, 0, 0, 0, time.UTC)
 	for !cur.After(endMonth) {
-		base := fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", campgroundID)
-		u, err := url.Parse(base)
-		if err != nil {
-			return nil, fmt.Errorf("invalid base url: %w", err)
-		}
-		q := u.Query()
-		// Recreation.gov expects RFC3339 with milliseconds and Zulu time.
-		q.Set("start_date", cur.UTC().Format("2006-01-02T15:04:05.000Z"))
-		u.RawQuery = q.Encode()
-		slog.Info("Fetching availability", slog.String("url", u.String()))
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-		httpx.SpoofChromeHeaders(req)
-		resp, err := r.client.Do(req)
-		if err != nil {
-			slog.Error("availability GET failed", slog.Any("err", err))
-			return nil, fmt.Errorf("availability GET failed: %w", err)
-		}
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			slog.Error("availability read body failed", slog.Any("err", err))
-			return nil, fmt.Errorf("availability read body failed: %w", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			slog.Error("availability request failed, not ok", slog.Int("status", resp.StatusCode), slog.String("body", clipBody(body)))
-			return nil, fmt.Errorf("recreation.gov availability status %d; body: %s", resp.StatusCode, clipBody(body))
-		}
-		var parsed recGovResp
-		err = json.Unmarshal(body, &parsed)
-		if err != nil {
-			slog.Error("availability JSON decode failed", slog.Any("err", err), slog.String("body", clipBody(body)))
-			return nil, fmt.Errorf("availability JSON decode failed: %w; body: %s", err, clipBody(body))
-		}
-		for siteID, data := range parsed.Campsites {
-			for dateStr, status := range data.Availabilities {
-				d, err := time.Parse(time.RFC3339, dateStr)
-				if err != nil {
-					slog.Error("bad date from rec.gov", slog.String("date", dateStr))
-					continue
-				}
-				out = append(out, CampsiteAvailability{
-					ID:        siteID,
-					Date:      d,
-					Available: status == "Available",
-				})
-			}
-		}
+		months = append(months, cur)
 		cur = cur.AddDate(0, 1, 0)
 	}
+	if len(months) == 0 {
+		return nil, nil
+	}
+
+	results := make([]monthResult, len(months))
+	var wg sync.WaitGroup
+	for i, m := range months {
+		wg.Add(1)
+		go func(i int, m time.Time) {
+			defer wg.Done()
+			results[i] = r.fetchOneMonth(ctx, campgroundID, m)
+		}(i, m)
+	}
+	wg.Wait()
+
+	var out []CampsiteAvailability
+	var firstErr error
+	for _, r := range results {
+		if r.err != nil && firstErr == nil {
+			firstErr = r.err
+			continue
+		}
+		out = append(out, r.out...)
+	}
+	if firstErr != nil && len(out) == 0 {
+		return nil, firstErr
+	}
 	return out, nil
+}
+
+func (r *RecreationGov) fetchOneMonth(ctx context.Context, campgroundID string, monthStart time.Time) (mr struct {
+	out []CampsiteAvailability
+	err error
+}) {
+	base := fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", campgroundID)
+	u, err := url.Parse(base)
+	if err != nil {
+		mr.err = fmt.Errorf("invalid base url: %w", err)
+		return
+	}
+	q := u.Query()
+	q.Set("start_date", monthStart.UTC().Format("2006-01-02T15:04:05.000Z"))
+	u.RawQuery = q.Encode()
+	slog.Info("Fetching availability", slog.String("url", u.String()))
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	httpx.SpoofChromeHeaders(req)
+	resp, err := r.client.Do(req)
+	if err != nil {
+		mr.err = fmt.Errorf("availability GET failed: %w", err)
+		return
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		mr.err = fmt.Errorf("availability read body failed: %w", err)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		mr.err = fmt.Errorf("recreation.gov availability status %d; body: %s", resp.StatusCode, clipBody(body))
+		return
+	}
+	var parsed recGovResp
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		mr.err = fmt.Errorf("availability JSON decode failed: %w; body: %s", err, clipBody(body))
+		return
+	}
+	for siteID, data := range parsed.Campsites {
+		for dateStr, status := range data.Availabilities {
+			d, err := time.Parse(time.RFC3339, dateStr)
+			if err != nil {
+				continue
+			}
+			mr.out = append(mr.out, CampsiteAvailability{
+				ID:        siteID,
+				Date:      d,
+				Available: status == "Available",
+			})
+		}
+	}
+	return
 }
 
 // PlanBuckets groups dates by month and returns one monthly range per group from day 1 to last day of month.

--- a/internal/providers/reservecalifornia.go
+++ b/internal/providers/reservecalifornia.go
@@ -152,7 +152,7 @@ func (r *ReserveCalifornia) FetchAvailability(ctx context.Context, campgroundID 
 		req.Header.Set("Referer", "https://www.reservecalifornia.com/")
 		req.Header.Set("tenantid", "cali")
 
-		time.Sleep(time.Duration(i) * 5000 * time.Millisecond) // Exponential backoff
+		time.Sleep(time.Duration(i) * 500 * time.Millisecond) // small per-retry backoff; proxy pool handles per-IP throttle
 
 		slog.Info("Fetching RC grid", slog.String("facility", facilityID), slog.String("start", payload.StartDate), slog.String("end", payload.EndDate))
 		resp, err := r.client.Do(req)

--- a/internal/proxypool/pool.go
+++ b/internal/proxypool/pool.go
@@ -100,7 +100,7 @@ func New(secret string) (*Pool, error) {
 		endpoints:   f.Endpoints,
 		secret:      secret,
 		client:      &http.Client{Timeout: 35 * time.Second},
-		flushAfter:  50 * time.Millisecond,
+		flushAfter:  10 * time.Millisecond,
 		maxBatch:    50,
 		cooldown:    60 * time.Second,
 		endpointBad: map[string]time.Time{},

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,77 @@
+# proxy
+
+Tiny Go HTTP forward-proxy. One container per Cloud Run region; schniffer
+routes outbound polling traffic through them to rotate egress IPs.
+
+## How it fits together
+
+- `main.go` — POST `/fetch` accepts a JSON batch of {url, method, headers,
+  body}, fans them out concurrently, returns the responses.
+- `Dockerfile` — distroless Go binary.
+- `regions.txt` — desired GCP region list. The `Deploy proxy` workflow
+  (`.github/workflows/deploy-proxy.yml`) builds the image once, deploys it to
+  every region in this file, and writes the resulting URLs into
+  `internal/proxypool/endpoints.json` (so schniffer picks them up on its
+  next deploy).
+- `deploy.sh` — local-machine version of the workflow; useful if you want to
+  push a fix without going through GitHub.
+
+## Running the proxy locally
+
+For a fast manual test of the batching shape (no GCP needed):
+
+```bash
+cd proxy
+PROXY_SECRET=local-test go run .
+```
+
+In another shell:
+
+```bash
+curl -s -X POST http://localhost:8080/fetch \
+  -H "Authorization: Bearer local-test" \
+  -H "Content-Type: application/json" \
+  -d '{"requests":[{"url":"https://httpbin.org/get"},{"url":"https://httpbin.org/ip"}]}' | jq
+```
+
+You should see two responses returned in a single call, each with `status:
+200` and the upstream body.
+
+## Running schniffer against the local proxy
+
+To test the full client → batching pool → proxy → upstream flow on your
+laptop without touching production:
+
+```bash
+# 1. Run the local proxy (above)
+
+# 2. Override the endpoint list so schniffer talks to localhost
+cat > /tmp/local-endpoints.json <<'EOF'
+{"endpoints":[{"url":"http://localhost:8080","provider":"local","region":"dev"}]}
+EOF
+cp /tmp/local-endpoints.json internal/proxypool/endpoints.json   # see note
+
+# 3. Run schniffer pointed at a temp sqlite, with the proxy enabled
+PROXY_SECRET=local-test \
+DB_PATH=/tmp/schniffer-dev.sqlite \
+DISCORD_TOKEN=fake \
+GUILD_ID=fake \
+go run ./cmd/schniffer
+```
+
+Note: `endpoints.json` is embedded into the binary at compile time
+(`//go:embed`), so you have to re-build (`go run` does this automatically)
+after editing it. Don't commit a local-only endpoints.json.
+
+## Manual smoke after deploying
+
+```bash
+PROXY_SECRET=$(gcloud secrets versions access latest --secret=proxy-secret --project=schniffer)
+URL=$(gcloud run services describe proxyrequest --region=us-central1 --project=schniffer --format='value(status.url)')
+curl -s -X POST "$URL/fetch" \
+  -H "Authorization: Bearer $PROXY_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"requests":[{"url":"https://www.recreation.gov/api/camps/availability/campground/10083567/month?start_date=2026-08-01T00%3A00%3A00.000Z"}]}' | jq '.responses[0].status'
+```
+
+Should print `200`.


### PR DESCRIPTION
## Summary
Audit-driven refactor of `manager.PollProvider` and a few neighboring spots to maximise polling throughput while keeping safe behaviour during upstream hiccups.

- **Fan out campgrounds concurrently** in `PollProvider`, sem-bounded at 32. With the proxy pool's request coalescing, all of them become a single batched outbound call.
- **Fan out per-month buckets** inside `RecreationGov.FetchAvailability`.
- **Don't abort the cycle on a single fetch error** — keep the rest going; only surface an error if > half failed in the same cycle.
- **Move `DeactivateExpiredRequests` to its own 5-min reaper goroutine** (was being scanned every 10s).
- **Batch `RecordLookup` writes** into one end-of-cycle insert through the writer.
- **Parallelize DM sends** in `ProcessNotificationsWithBatches` (bounded 5).
- **Shrink ReserveCalifornia retry sleeps** from `i * 5s` to `i * 500ms` — the proxy pool handles per-IP throttling now.
- **Shrink proxy-pool batch flush window** from 50ms to 10ms.

## Test plan
- [x] `TestPollProviderCampgroundsRunConcurrently` — 20 fake campgrounds × 100ms latency each finishes in ~100ms (peak concurrency 20). Serial would have been ~2s.
- [x] `TestPollProviderContinuesPastErrors` — one failing fetch out of 10 doesn't abort the cycle and `PollProvider` returns nil.
- [x] Full build and `go test ./internal/manager/ ./internal/proxypool/ ./internal/httpx/ ./internal/db/` green for everything not flaky on `main` already (`TestBuild*Embed*` were failing identically before this PR — out of scope).
- [ ] After deploy, live `schniffer-bot` shows >1 `Fetching availability` log in the same millisecond (parallelism in production) and no sustained 429 spam.

Local end-to-end sanity steps documented in `proxy/README.md`.