### PR TITLE
fix: scope /schniff remove to caller, add explicit remove-all

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -146,9 +146,10 @@ func (b *Bot) registerCommands() {
 					{Name: "checkout", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Check-out (YYYY-MM-DD)"},
 				}},
 				{Name: "map", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Open map to create groups or quickly see availability at a site."},
-				{Name: "remove", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove a schniff. Blank id removes all.", Options: []*discordgo.ApplicationCommandOption{
-					{Name: "ids", Type: discordgo.ApplicationCommandOptionInteger, Required: false, Description: "Request ID to remove", Autocomplete: true},
+				{Name: "remove", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove a single schniff by id.", Options: []*discordgo.ApplicationCommandOption{
+					{Name: "ids", Type: discordgo.ApplicationCommandOptionInteger, Required: true, Description: "Request ID to remove", Autocomplete: true},
 				}},
+				{Name: "remove-all", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove ALL of your active schniffs."},
 				{Name: "list", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "List all your active schniffs"},
 				{Name: "summary", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Get summary of schniff activity for all users"},
 				// {Name: "nonsense", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Broadcast a silly greeting to the channel"},
@@ -237,6 +238,8 @@ func (b *Bot) handleApplicationCommand(s *discordgo.Session, i *discordgo.Intera
 		b.handleLinkMapCommand(s, i, sub)
 	case "remove":
 		b.handleRemoveCommand(s, i, sub)
+	case "remove-all":
+		b.handleRemoveAllCommand(s, i, sub)
 	case "list":
 		b.handleListCommand(s, i, sub)
 	case "summary":

--- a/internal/bot/handler_remove.go
+++ b/internal/bot/handler_remove.go
@@ -12,34 +12,42 @@ func (b *Bot) handleRemoveCommand(s *discordgo.Session, i *discordgo.Interaction
 	uid := getUserID(i)
 	opts := optMap(sub.Options)
 	opt, ok := opts["ids"]
-	if ok && opt != nil {
-		id := int64(opt.IntValue())
-		err := b.store.DeactivateRequest(context.Background(), id, uid)
-		if err != nil {
-			respond(s, i, "error: "+err.Error())
-			return
-		}
-		respond(s, i, "removed")
+	if !ok || opt == nil {
+		respond(s, i, "you have to tell me what to remove bro. pick an id, or use /schniff remove-all")
 		return
 	}
+	id := int64(opt.IntValue())
+	if id <= 0 {
+		respond(s, i, "you have to tell me what to remove bro. pick an id, or use /schniff remove-all")
+		return
+	}
+	if err := b.store.DeactivateRequest(context.Background(), id, uid); err != nil {
+		respond(s, i, "error: "+err.Error())
+		return
+	}
+	respond(s, i, "removed")
+}
 
-	// No ID provided, remove all schniffs
-	reqs, err := b.store.ListActiveRequests(context.Background())
+func (b *Bot) handleRemoveAllCommand(s *discordgo.Session, i *discordgo.InteractionCreate, _ *discordgo.ApplicationCommandInteractionDataOption) {
+	uid := getUserID(i)
+	reqs, err := b.store.ListUserActiveRequests(context.Background(), uid)
 	if err != nil {
 		b.logger.Warn("list active reqs failed", "err", err)
 		respond(s, i, "failed to get schniffs to remove")
 		return
 	}
-
+	if len(reqs) == 0 {
+		respond(s, i, "you have no active schniffs")
+		return
+	}
 	for _, r := range reqs {
-		err = b.store.DeactivateRequest(context.Background(), r.ID, r.UserID)
-		if err != nil {
+		if err := b.store.DeactivateRequest(context.Background(), r.ID, uid); err != nil {
 			respond(s, i, "error: "+err.Error())
 			return
 		}
-		slog.Info("Removed schniff for user", "id", r.ID, "user_id", r.UserID)
+		slog.Info("Removed schniff for user", "id", r.ID, "user_id", uid)
 	}
-	respond(s, i, "removed all schniffs")
+	respond(s, i, "removed all your schniffs")
 }
 
 // autocompleteRemoveIDs suggests the caller's active schniffs as choices.


### PR DESCRIPTION
## Summary
- `/schniff remove` without an `ids` arg used `ListActiveRequests` (every user's active schniffs) and called `DeactivateRequest` with each row's own `UserID` — one argless invocation wiped active schniffs across all users.
- Make `ids` required on `/schniff remove`, and split the bulk-clear into a new `/schniff remove-all` subcommand scoped to the calling user via `ListUserActiveRequests(ctx, uid)` + `DeactivateRequest(ctx, r.ID, uid)`.

## Test plan
- [ ] `/schniff remove` with no id → Discord rejects (option now required); the handler's defensive fallback returns "you have to tell me what to remove bro. pick an id, or use /schniff remove-all".
- [ ] `/schniff remove <id>` for an id you own → removes only that one.
- [ ] `/schniff remove <id>` for an id another user owns → "not found or not owner".
- [ ] `/schniff remove-all` → removes only the caller's active schniffs; other users untouched.
- [ ] `/schniff remove-all` with no active schniffs → "you have no active schniffs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)