### PR TITLE
test: pin [checkin, checkout) per-night semantics

### DIFF
--- a/internal/db/fencepost_test.go
+++ b/internal/db/fencepost_test.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// fenceDay is a small helper for readable UTC midnight dates used by these tests.
+func fenceDay(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// setupFenceDB creates the tables used by the date-range queries we exercise here.
+func setupFenceDB(t *testing.T) *Store {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	stmts := []string{
+		`CREATE TABLE campsite_availability (
+			provider TEXT, campground_id TEXT, campsite_id TEXT,
+			date DATETIME, available INTEGER, last_checked DATETIME,
+			PRIMARY KEY (provider, campground_id, campsite_id, date)
+		)`,
+		`CREATE TABLE state_changes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider TEXT, campground_id TEXT, campsite_id TEXT,
+			date DATETIME, new_available INTEGER,
+			changed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE notifications (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			batch_id TEXT,
+			request_id INTEGER,
+			user_id TEXT, provider TEXT, campground_id TEXT, campsite_id TEXT,
+			date DATETIME, state TEXT, state_change_id INTEGER,
+			sent_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("schema: %v", err)
+		}
+	}
+	return &Store{DB: db}
+}
+
+// TestGetCurrentlyAvailableCampsites_Fencepost confirms the SQL range filter is
+// [checkin, checkout) — i.e., checkin day IS included (the arrival night) and
+// checkout day is NOT included (you've already left). The motivating bug case:
+// a Fri->Sun request must not pick up a Thursday-night availability row, but
+// must pick up the Friday and Saturday nights.
+func TestGetCurrentlyAvailableCampsites_Fencepost(t *testing.T) {
+	store := setupFenceDB(t)
+	ctx := context.Background()
+
+	wed := fenceDay(2025, 8, 13)
+	thu := fenceDay(2025, 8, 14)
+	fri := fenceDay(2025, 8, 15)
+	sat := fenceDay(2025, 8, 16)
+	sun := fenceDay(2025, 8, 17)
+	mon := fenceDay(2025, 8, 18)
+
+	// Seed one campsite as available across the whole week.
+	for _, d := range []time.Time{wed, thu, fri, sat, sun, mon} {
+		_, err := store.DB.ExecContext(ctx, `
+			INSERT INTO campsite_availability(provider, campground_id, campsite_id, date, available, last_checked)
+			VALUES ('p', 'cg', 's1', ?, 1, ?)
+		`, d, time.Now())
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// Fri->Sun request: nights are Fri and Sat only.
+	got, err := store.GetCurrentlyAvailableCampsites(ctx, "p", "cg", fri, sun)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	wantDates := map[string]bool{
+		fri.Format("2006-01-02"): true,
+		sat.Format("2006-01-02"): true,
+	}
+	bannedDates := map[string]bool{
+		wed.Format("2006-01-02"): true,
+		thu.Format("2006-01-02"): true, // the bug-report case
+		sun.Format("2006-01-02"): true, // checkout day must be excluded
+		mon.Format("2006-01-02"): true,
+	}
+
+	gotDates := map[string]bool{}
+	for _, it := range got {
+		k := it.Date.UTC().Format("2006-01-02")
+		gotDates[k] = true
+		if bannedDates[k] {
+			t.Errorf("unexpected date in result: %s (Fri->Sun request must not return this)", k)
+		}
+	}
+	for d := range wantDates {
+		if !gotDates[d] {
+			t.Errorf("missing expected date in result: %s", d)
+		}
+	}
+}
+
+// TestGetUnnotifiedStateChanges_Fencepost is the end-to-end check that motivated
+// the bug report: a state-change row for a Thursday-night flip-to-available must
+// NOT surface as a notifyable change for a Fri->Sun request.
+func TestGetUnnotifiedStateChanges_Fencepost(t *testing.T) {
+	store := setupFenceDB(t)
+	ctx := context.Background()
+
+	thu := fenceDay(2025, 8, 14)
+	fri := fenceDay(2025, 8, 15)
+	sat := fenceDay(2025, 8, 16)
+	sun := fenceDay(2025, 8, 17)
+
+	// Seed three state changes: Thu (out of range), Fri (in range), Sun (out of range, == checkout day).
+	for _, d := range []time.Time{thu, fri, sun} {
+		_, err := store.DB.ExecContext(ctx, `
+			INSERT INTO state_changes(provider, campground_id, campsite_id, date, new_available)
+			VALUES ('p', 'cg', 's1', ?, 1)
+		`, d)
+		if err != nil {
+			t.Fatalf("seed state_change: %v", err)
+		}
+	}
+
+	req := SchniffRequest{
+		ID: 42, UserID: "u", Provider: "p", CampgroundID: "cg",
+		Checkin: fri, Checkout: sun, Active: true,
+	}
+
+	changes, err := store.GetUnnotifiedStateChanges(ctx, []SchniffRequest{req})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	if len(changes) != 1 {
+		t.Fatalf("expected exactly 1 in-range state change, got %d (%+v)", len(changes), changes)
+	}
+	gotDate := changes[0].Date.UTC().Format("2006-01-02")
+	if gotDate != fri.Format("2006-01-02") {
+		t.Errorf("expected Fri state change, got %s", gotDate)
+	}
+
+	// Saturday isn't even in the seeded set — sanity guard so this test breaks loudly
+	// if the seed expands but the assertions aren't updated.
+	_ = sat
+}

--- a/internal/manager/fencepost_test.go
+++ b/internal/manager/fencepost_test.go
@@ -1,0 +1,117 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brensch/schniffer/internal/db"
+)
+
+// day is a tiny helper for readable UTC midnight dates.
+func day(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// TestGenerateNights_Fencepost pins down the [checkin, checkout) per-night
+// semantics: checkin is the day of arrival (you sleep that night), checkout
+// is the day of departure (you do NOT sleep that night).
+//
+// The motivating bug report: a user with a Fri->Sun request worried they were
+// matching a Thu->Fri (Thursday-night-only) campground availability. With
+// these semantics, Fri->Sun generates nights {Fri, Sat} and the lone Thursday
+// night cannot match.
+func TestGenerateNights_Fencepost(t *testing.T) {
+	thu := day(2025, 8, 14)
+	fri := day(2025, 8, 15)
+	sat := day(2025, 8, 16)
+	sun := day(2025, 8, 17)
+
+	cases := []struct {
+		name     string
+		checkin  time.Time
+		checkout time.Time
+		want     []time.Time
+	}{
+		{"single-night Thu->Fri", thu, fri, []time.Time{thu}},
+		{"single-night Fri->Sat", fri, sat, []time.Time{fri}},
+		{"two-night Fri->Sun (Fri+Sat)", fri, sun, []time.Time{fri, sat}},
+		{"three-night Thu->Sun", thu, sun, []time.Time{thu, fri, sat}},
+		{"zero range Fri->Fri yields no nights", fri, fri, nil},
+		{"inverted Sun->Fri yields no nights", sun, fri, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generateNights(tc.checkin, tc.checkout)
+			if len(got) != len(tc.want) {
+				t.Fatalf("nights len = %d, want %d (got=%v want=%v)", len(got), len(tc.want), got, tc.want)
+			}
+			for i := range got {
+				if !got[i].Equal(tc.want[i]) {
+					t.Fatalf("night[%d] = %s, want %s", i, got[i].Format("2006-01-02"), tc.want[i].Format("2006-01-02"))
+				}
+			}
+		})
+	}
+}
+
+// TestGenerateNights_ThuFriDoesNotOverlapFriSun is the explicit case from the
+// bug report: a Thursday-night-only campground stay must not be considered
+// part of a Friday-arrival, Sunday-departure request.
+func TestGenerateNights_ThuFriDoesNotOverlapFriSun(t *testing.T) {
+	thu := day(2025, 8, 14)
+	fri := day(2025, 8, 15)
+	sun := day(2025, 8, 17)
+
+	requested := generateNights(fri, sun) // {Fri, Sat}
+	campground := generateNights(thu, fri) // {Thu}
+
+	for _, want := range requested {
+		for _, have := range campground {
+			if want.Equal(have) {
+				t.Fatalf("unexpected overlap on %s: Thu-only campground availability must not match Fri->Sun request",
+					want.Format("2006-01-02"))
+			}
+		}
+	}
+}
+
+// TestCollectDatesByPC_FencepostFiltering verifies that the per-(provider,
+// campground) date set the polling loop builds from active requests respects
+// per-night semantics and drops malformed requests where checkout <= checkin.
+func TestCollectDatesByPC_FencepostFiltering(t *testing.T) {
+	fri := day(2025, 8, 15)
+	sat := day(2025, 8, 16)
+	sun := day(2025, 8, 17)
+
+	reqs := []db.SchniffRequest{
+		// Fri->Sun => nights Fri, Sat
+		{ID: 1, Provider: "p", CampgroundID: "cg", Checkin: fri, Checkout: sun, Active: true},
+		// Same-day, must be ignored.
+		{ID: 2, Provider: "p", CampgroundID: "cg", Checkin: fri, Checkout: fri, Active: true},
+		// Inverted, must be ignored.
+		{ID: 3, Provider: "p", CampgroundID: "cg", Checkin: sun, Checkout: fri, Active: true},
+	}
+
+	dates, byPC := collectDatesByPC(reqs)
+	key := pc{prov: "p", cg: "cg"}
+
+	set := dates[key]
+	if len(set) != 2 {
+		t.Fatalf("expected 2 unique nights, got %d (%v)", len(set), set)
+	}
+	if _, ok := set[fri]; !ok {
+		t.Errorf("expected Fri in night set")
+	}
+	if _, ok := set[sat]; !ok {
+		t.Errorf("expected Sat in night set")
+	}
+	if _, ok := set[sun]; ok {
+		t.Errorf("checkout day (Sun) must not appear as a night")
+	}
+
+	// Only the valid request should be retained per-PC.
+	if len(byPC[key]) != 1 || byPC[key][0].ID != 1 {
+		t.Errorf("expected only request 1 retained, got %+v", byPC[key])
+	}
+}


### PR DESCRIPTION
Adds unit/SQLite tests that lock down the fencepost behaviour for schniff request matching: checkin is the arrival night (included), checkout is the departure morning (excluded). Covers generateNights, collectDatesByPC, GetCurrentlyAvailableCampsites, and GetUnnotifiedStateChanges so a Thursday-only availability cannot silently match a Fri->Sun request.