### PR TITLE
[codex] Fix browser session contexts

### DIFF
--- a/internal/booker/pool.go
+++ b/internal/booker/pool.go
@@ -147,7 +147,9 @@ func (p *Pool) HoldCampsite(ctx context.Context, userID, campsiteID, campgroundI
 	if e.disabled {
 		return nil, errors.New("session disabled")
 	}
-	return e.session.HoldCampsite(ctx, campsiteID, campgroundID, checkIn, checkOut)
+	opCtx, cancel := sessionOperationContext(e.session.Ctx(), ctx)
+	defer cancel()
+	return e.session.HoldCampsite(opCtx, campsiteID, campgroundID, checkIn, checkOut)
 }
 
 // RunRefreshLoop nav's each session to the homepage every cfg.RefreshInterval
@@ -180,12 +182,36 @@ func (p *Pool) refreshAll(ctx context.Context) {
 			continue
 		}
 		e.mu.Lock()
-		rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 30*time.Second)
+		rctx, cancel := sessionOperationContext(e.session.Ctx(), timeoutCtx)
 		if err := e.session.Refresh(rctx); err != nil {
 			p.cfg.Logger.Warn("session refresh failed", "user", id, "err", err)
 		}
 		cancel()
+		timeoutCancel()
 		e.mu.Unlock()
+	}
+}
+
+// sessionOperationContext keeps chromedp's browser metadata from sessionCtx
+// while propagating the caller's cancellation and deadline.
+func sessionOperationContext(sessionCtx, callerCtx context.Context) (context.Context, context.CancelFunc) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if deadline, ok := callerCtx.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(sessionCtx, deadline)
+	} else {
+		ctx, cancel = context.WithCancel(sessionCtx)
+	}
+	stop := context.AfterFunc(callerCtx, cancel)
+	if callerCtx.Err() != nil {
+		cancel()
+	}
+	return ctx, func() {
+		stop()
+		cancel()
 	}
 }
 

--- a/internal/booker/pool_test.go
+++ b/internal/booker/pool_test.go
@@ -1,0 +1,60 @@
+package booker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+func TestSessionOperationContextPreservesChromedpContext(t *testing.T) {
+	sessionCtx, closeSession := chromedp.NewContext(context.Background())
+	defer closeSession()
+
+	opCtx, cancel := sessionOperationContext(sessionCtx, context.Background())
+	defer cancel()
+
+	if chromedp.FromContext(opCtx) == nil {
+		t.Fatal("operation context lost chromedp session metadata")
+	}
+}
+
+func TestSessionOperationContextPropagatesCallerCancellation(t *testing.T) {
+	sessionCtx, closeSession := chromedp.NewContext(context.Background())
+	defer closeSession()
+	callerCtx, cancelCaller := context.WithCancel(context.Background())
+
+	opCtx, cancel := sessionOperationContext(sessionCtx, callerCtx)
+	defer cancel()
+	cancelCaller()
+
+	select {
+	case <-opCtx.Done():
+		if !errors.Is(opCtx.Err(), context.Canceled) {
+			t.Fatalf("operation context error = %v, want context canceled", opCtx.Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("operation context was not canceled with caller")
+	}
+}
+
+func TestSessionOperationContextPropagatesCallerDeadline(t *testing.T) {
+	sessionCtx, closeSession := chromedp.NewContext(context.Background())
+	defer closeSession()
+	wantDeadline := time.Now().Add(time.Minute)
+	callerCtx, cancelCaller := context.WithDeadline(context.Background(), wantDeadline)
+	defer cancelCaller()
+
+	opCtx, cancel := sessionOperationContext(sessionCtx, callerCtx)
+	defer cancel()
+
+	gotDeadline, ok := opCtx.Deadline()
+	if !ok {
+		t.Fatal("operation context has no deadline")
+	}
+	if !gotDeadline.Equal(wantDeadline) {
+		t.Fatalf("operation deadline = %v, want %v", gotDeadline, wantDeadline)
+	}
+}


### PR DESCRIPTION
## What changed

- derive booking and refresh operation contexts from each user's chromedp session
- preserve caller deadlines and cancellation without dropping chromedp browser metadata
- add regression tests for browser metadata, cancellation, and deadline propagation

## Why

The first auto-booking attempt for campground `232452`, site `785`, failed with `nav: invalid context`. The manager's generic polling context was passed directly to `chromedp.Run`, but chromedp requires a context derived from the browser session.

This also affected the periodic browser refresh path.

## Impact

Auto-booking navigation and session refresh now run against the correct warm browser while retaining their existing timeout and shutdown behavior.

## Validation

- `go test ./internal/booker`
- `go test -race ./internal/booker`
- `go test -run '^$' ./...`
- `go vet ./internal/booker`