### PR TITLE
feat(schniff): minimum_nights + strategy filters, CI, test cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: gofmt
+        run: |
+          out=$(gofmt -l cmd internal proxy)
+          if [ -n "$out" ]; then
+            echo "::error::The following files are not gofmt-clean:"
+            echo "$out"
+            echo
+            echo "Run 'gofmt -w cmd internal proxy' and commit."
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test -short -race -count=1 -timeout 5m ./...

--- a/cmd/booker/main.go
+++ b/cmd/booker/main.go
@@ -3,8 +3,9 @@
 // binary is for developer-driven smoke tests inside the docker container.
 //
 // Usage:
-//   REC_GOV_EMAIL=... REC_GOV_PASSWORD=... go run ./cmd/booker \
-//     -campsite 10085607 -campground 10085599 -from 2026-06-25 -nights 1
+//
+//	REC_GOV_EMAIL=... REC_GOV_PASSWORD=... go run ./cmd/booker \
+//	  -campsite 10085607 -campground 10085599 -from 2026-06-25 -nights 1
 package main
 
 import (

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -152,11 +152,15 @@ func (b *Bot) registerCommands() {
 					{Name: "campground", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Select campground", Autocomplete: true},
 					{Name: "checkin", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Check-in (YYYY-MM-DD)"},
 					{Name: "checkout", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Check-out (YYYY-MM-DD)"},
+					{Name: "minimum_nights", Type: discordgo.ApplicationCommandOptionInteger, Required: false, Description: "Only fire if one campsite has this many consecutive nights free", Autocomplete: true},
+					{Name: "strategy", Type: discordgo.ApplicationCommandOptionString, Required: false, Description: "Extra condition before notifying/booking", Choices: strategyChoices()},
 				}},
 				{Name: "add-bulk", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Add a schniff for all campgrounds in a group. Use `/schniff map` to make groups.", Options: []*discordgo.ApplicationCommandOption{
 					{Name: "group", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Select group", Autocomplete: true},
 					{Name: "checkin", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Check-in (YYYY-MM-DD)"},
 					{Name: "checkout", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Check-out (YYYY-MM-DD)"},
+					{Name: "minimum_nights", Type: discordgo.ApplicationCommandOptionInteger, Required: false, Description: "Only fire if one campsite has this many consecutive nights free", Autocomplete: true},
+					{Name: "strategy", Type: discordgo.ApplicationCommandOptionString, Required: false, Description: "Extra condition before notifying/booking", Choices: strategyChoices()},
 				}},
 				{Name: "map", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Open map to create groups or quickly see availability at a site."},
 				{Name: "remove", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove a single schniff by id.", Options: []*discordgo.ApplicationCommandOption{
@@ -165,8 +169,8 @@ func (b *Bot) registerCommands() {
 				{Name: "remove-all", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove ALL of your active schniffs."},
 				{Name: "list", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "List all your active schniffs"},
 				{Name: "summary", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Get summary of schniff activity for all users"},
-					{Name: "link", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Link your recreation.gov account so schniffer can auto-add hits to your cart"},
-					{Name: "unlink", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove your stored recreation.gov credentials"},
+				{Name: "link", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Link your recreation.gov account so schniffer can auto-add hits to your cart"},
+				{Name: "unlink", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove your stored recreation.gov credentials"},
 				// {Name: "nonsense", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Broadcast a silly greeting to the channel"},
 			},
 		},
@@ -222,6 +226,8 @@ func (b *Bot) handleAutocomplete(s *discordgo.Session, i *discordgo.InteractionC
 		choices = b.autocompleteGroups(i, focused.StringValue())
 	case "ids":
 		choices = b.autocompleteRemoveIDs(i)
+	case "minimum_nights":
+		choices = autocompleteMinimumNights(sub.Options)
 	}
 	if choices == nil {
 		return

--- a/internal/bot/handler_add.go
+++ b/internal/bot/handler_add.go
@@ -49,8 +49,22 @@ func (b *Bot) handleAddCommand(s *discordgo.Session, i *discordgo.InteractionCre
 		return
 	}
 
+	minN, strat, ferr := parseScheduleFilters(opts, start, end)
+	if ferr != "" {
+		respond(s, i, ferr)
+		return
+	}
+
 	uid := getUserID(i)
-	_, err = b.store.AddRequest(context.Background(), db.SchniffRequest{UserID: uid, Provider: campgroundProvider, CampgroundID: campgroundID, Checkin: start, Checkout: end})
+	_, err = b.store.AddRequest(context.Background(), db.SchniffRequest{
+		UserID:        uid,
+		Provider:      campgroundProvider,
+		CampgroundID:  campgroundID,
+		Checkin:       start,
+		Checkout:      end,
+		MinimumNights: minN,
+		Strategy:      strat,
+	})
 	if err != nil {
 		respond(s, i, "error: "+err.Error())
 		return
@@ -59,7 +73,14 @@ func (b *Bot) handleAddCommand(s *discordgo.Session, i *discordgo.InteractionCre
 	// get the length of the stay
 	stayDuration := end.Sub(start)
 	formattedName := b.formatCampgroundWithLink(context.Background(), campgroundProvider, campgroundID, campgroundName)
-	respond(s, i, fmt.Sprintf("Now schniffing: %s, dates %s to %s (%.0f nights)", formattedName, start.Format("2006-01-02"), end.Format("2006-01-02"), stayDuration.Hours()/24))
+	msg := fmt.Sprintf("Now schniffing: %s, dates %s to %s (%.0f nights)", formattedName, start.Format("2006-01-02"), end.Format("2006-01-02"), stayDuration.Hours()/24)
+	if minN.Valid {
+		msg += fmt.Sprintf(", minimum_nights=%d", minN.Int64)
+	}
+	if strat.Valid {
+		msg += fmt.Sprintf(", strategy=%s", strat.String)
+	}
+	respond(s, i, msg)
 }
 
 func (b *Bot) autocompleteCampgrounds(i *discordgo.InteractionCreate, query string) []*discordgo.ApplicationCommandOptionChoice {

--- a/internal/bot/handler_addbulk.go
+++ b/internal/bot/handler_addbulk.go
@@ -64,6 +64,12 @@ func (b *Bot) handleAddBulkCommand(s *discordgo.Session, i *discordgo.Interactio
 		return
 	}
 
+	minN, strat, ferr := parseScheduleFilters(opts, start, end)
+	if ferr != "" {
+		respond(s, i, ferr)
+		return
+	}
+
 	uid := getUserID(i)
 
 	// Get the group and verify ownership
@@ -79,11 +85,13 @@ func (b *Bot) handleAddBulkCommand(s *discordgo.Session, i *discordgo.Interactio
 
 	for _, campgroundRef := range group.Campgrounds {
 		_, err := b.store.AddRequest(context.Background(), db.SchniffRequest{
-			UserID:       uid,
-			Provider:     campgroundRef.Provider,
-			CampgroundID: campgroundRef.CampgroundID,
-			Checkin:      start,
-			Checkout:     end,
+			UserID:        uid,
+			Provider:      campgroundRef.Provider,
+			CampgroundID:  campgroundRef.CampgroundID,
+			Checkin:       start,
+			Checkout:      end,
+			MinimumNights: minN,
+			Strategy:      strat,
 		})
 
 		if err != nil {
@@ -101,6 +109,12 @@ func (b *Bot) handleAddBulkCommand(s *discordgo.Session, i *discordgo.Interactio
 		groupName, successCount, len(group.Campgrounds),
 		start.Format("2006-01-02"), end.Format("2006-01-02"),
 		stayDuration.Hours()/24)
+	if minN.Valid {
+		responseMsg += fmt.Sprintf(", minimum_nights=%d", minN.Int64)
+	}
+	if strat.Valid {
+		responseMsg += fmt.Sprintf(", strategy=%s", strat.String)
+	}
 
 	if len(errors) > 0 {
 		responseMsg += "\n\nErrors:\n" + strings.Join(errors, "\n")

--- a/internal/bot/handler_filters.go
+++ b/internal/bot/handler_filters.go
@@ -1,0 +1,92 @@
+package bot
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/brensch/schniffer/internal/db"
+	"github.com/bwmarrin/discordgo"
+)
+
+// strategyChoices returns the curated set of strategies surfaced in Discord.
+// Keep in sync with db.ValidStrategies.
+func strategyChoices() []*discordgo.ApplicationCommandOptionChoice {
+	return []*discordgo.ApplicationCommandOptionChoice{
+		{Name: "Full weekend (Fri + Sat nights free)", Value: db.StrategyFullWeekend},
+	}
+}
+
+// autocompleteMinimumNights suggests night counts based on the user's
+// currently-typed checkin/checkout. Top option is the full span, descending
+// down to 1.
+func autocompleteMinimumNights(opts []*discordgo.ApplicationCommandInteractionDataOption) []*discordgo.ApplicationCommandOptionChoice {
+	var checkin, checkout string
+	for _, o := range opts {
+		switch o.Name {
+		case "checkin":
+			checkin = o.StringValue()
+		case "checkout":
+			checkout = o.StringValue()
+		}
+	}
+	span := 0
+	if checkin != "" && checkout != "" {
+		start, end, err := parseDates(checkin, checkout)
+		if err == nil && end.After(start) {
+			span = int(end.Sub(start).Hours() / 24)
+		}
+	}
+	if span <= 0 {
+		// Fall back to a small static range so the suggestion list is never empty.
+		span = 7
+	}
+	if span > 25 {
+		span = 25 // Discord limit
+	}
+	out := make([]*discordgo.ApplicationCommandOptionChoice, 0, span)
+	for n := span; n >= 1; n-- {
+		label := fmt.Sprintf("%d night", n)
+		if n != 1 {
+			label += "s"
+		}
+		out = append(out, &discordgo.ApplicationCommandOptionChoice{
+			Name:  label,
+			Value: n,
+		})
+	}
+	return out
+}
+
+// parseScheduleFilters extracts and validates the optional minimum_nights and
+// strategy options against the requested window [start, end). Returns the
+// stored DB values plus a user-facing error message when validation fails.
+func parseScheduleFilters(opts map[string]*discordgo.ApplicationCommandInteractionDataOption, start, end time.Time) (sql.NullInt64, sql.NullString, string) {
+	var minN sql.NullInt64
+	var strat sql.NullString
+
+	nights := int(end.Sub(start).Hours() / 24)
+
+	if o, ok := opts["minimum_nights"]; ok && o != nil {
+		v := o.IntValue()
+		if v < 1 {
+			return minN, strat, "minimum_nights must be at least 1"
+		}
+		if v > int64(nights) {
+			return minN, strat, fmt.Sprintf("minimum_nights (%d) cannot exceed the %d night window", v, nights)
+		}
+		minN = sql.NullInt64{Int64: v, Valid: true}
+	}
+
+	if o, ok := opts["strategy"]; ok && o != nil {
+		s := strings.TrimSpace(o.StringValue())
+		if s != "" {
+			if !db.IsValidStrategy(s) {
+				return minN, strat, fmt.Sprintf("unknown strategy %q (valid: %s)", s, strings.Join(db.ValidStrategies, ", "))
+			}
+			strat = sql.NullString{String: s, Valid: true}
+		}
+	}
+	return minN, strat, ""
+}

--- a/internal/db/booking.go
+++ b/internal/db/booking.go
@@ -19,18 +19,18 @@ type UserCredential struct {
 }
 
 type Booking struct {
-	ID            int64
-	BatchID       string
-	UserID        string
-	Provider      string
-	CampgroundID  string
-	CampsiteID    string
-	Checkin       time.Time
-	Checkout      time.Time
-	Outcome       string
-	OrderID       *string
-	ErrorMsg      *string
-	AttemptedAt   time.Time
+	ID           int64
+	BatchID      string
+	UserID       string
+	Provider     string
+	CampgroundID string
+	CampsiteID   string
+	Checkin      time.Time
+	Checkout     time.Time
+	Outcome      string
+	OrderID      *string
+	ErrorMsg     *string
+	AttemptedAt  time.Time
 }
 
 const (

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -8,7 +8,9 @@ CREATE TABLE IF NOT EXISTS schniff_requests (
     checkin     DATE NOT NULL,
     checkout    DATE NOT NULL,
     created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
-    active      BOOLEAN DEFAULT TRUE
+    active      BOOLEAN DEFAULT TRUE,
+    minimum_nights INTEGER, -- optional: only notify/book if a single campsite covers this many consecutive nights inside the window
+    strategy    TEXT        -- optional: e.g. 'full_weekend'; only notify/book when the named condition is met
 );
 
 CREATE INDEX IF NOT EXISTS idx_schniff_requests_active ON schniff_requests(active);

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -244,7 +244,22 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 	_, err = db.Exec(string(schemaBytes))
-	return err
+	if err != nil {
+		return err
+	}
+	// Idempotent column additions for existing databases.
+	for _, alter := range []string{
+		`ALTER TABLE schniff_requests ADD COLUMN minimum_nights INTEGER`,
+		`ALTER TABLE schniff_requests ADD COLUMN strategy TEXT`,
+	} {
+		if _, aerr := db.Exec(alter); aerr != nil {
+			msg := aerr.Error()
+			if !strings.Contains(msg, "duplicate column") {
+				return fmt.Errorf("apply migration %q: %w", alter, aerr)
+			}
+		}
+	}
+	return nil
 }
 
 // Models
@@ -258,6 +273,35 @@ type SchniffRequest struct {
 	Checkout     time.Time
 	CreatedAt    time.Time
 	Active       bool
+	// MinimumNights, when set, requires at least one campsite to be available
+	// for this many consecutive nights inside [Checkin, Checkout) before a
+	// notification (or auto-booking) fires.
+	MinimumNights sql.NullInt64
+	// Strategy, when set, names a higher-level filter (e.g. "full_weekend")
+	// applied before notifying/booking.
+	Strategy sql.NullString
+}
+
+// Strategy values supported by the notifier filter. Add new entries here as
+// they are introduced.
+const (
+	StrategyFullWeekend = "full_weekend"
+)
+
+// ValidStrategies enumerates the strategy strings accepted by AddRequest.
+// Keep aligned with the Discord autocomplete in the bot package.
+var ValidStrategies = []string{StrategyFullWeekend}
+
+// IsValidStrategy reports whether s is a recognised strategy. The empty
+// string is treated as "no strategy" and is not valid here — callers should
+// gate on emptiness before calling.
+func IsValidStrategy(s string) bool {
+	for _, v := range ValidStrategies {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 type CampsiteAvailability struct {
@@ -381,10 +425,16 @@ type DetailedSummaryStats struct {
 // CRUD
 
 func (s *Store) AddRequest(ctx context.Context, r SchniffRequest) (int64, error) {
+	if r.Strategy.Valid && r.Strategy.String != "" && !IsValidStrategy(r.Strategy.String) {
+		return 0, fmt.Errorf("invalid strategy %q", r.Strategy.String)
+	}
+	if r.MinimumNights.Valid && r.MinimumNights.Int64 < 1 {
+		return 0, fmt.Errorf("minimum_nights must be >= 1")
+	}
 	result, err := s.DB.ExecContext(ctx, `
-		INSERT INTO schniff_requests(user_id, provider, campground_id, checkin, checkout, created_at, active)
-		VALUES (?, ?, ?, ?, ?, datetime('now'), true)
-	`, r.UserID, r.Provider, r.CampgroundID, r.Checkin, r.Checkout)
+		INSERT INTO schniff_requests(user_id, provider, campground_id, checkin, checkout, created_at, active, minimum_nights, strategy)
+		VALUES (?, ?, ?, ?, ?, datetime('now'), true, ?, ?)
+	`, r.UserID, r.Provider, r.CampgroundID, r.Checkin, r.Checkout, r.MinimumNights, r.Strategy)
 	if err != nil {
 		return 0, err
 	}
@@ -393,7 +443,7 @@ func (s *Store) AddRequest(ctx context.Context, r SchniffRequest) (int64, error)
 
 func (s *Store) ListActiveRequests(ctx context.Context) ([]SchniffRequest, error) {
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, user_id, provider, campground_id, checkin, checkout, created_at, active
+		SELECT id, user_id, provider, campground_id, checkin, checkout, created_at, active, minimum_nights, strategy
 		FROM schniff_requests WHERE active=true
 	`)
 	if err != nil {
@@ -403,7 +453,7 @@ func (s *Store) ListActiveRequests(ctx context.Context) ([]SchniffRequest, error
 	var out []SchniffRequest
 	for rows.Next() {
 		var r SchniffRequest
-		err := rows.Scan(&r.ID, &r.UserID, &r.Provider, &r.CampgroundID, &r.Checkin, &r.Checkout, &r.CreatedAt, &r.Active)
+		err := rows.Scan(&r.ID, &r.UserID, &r.Provider, &r.CampgroundID, &r.Checkin, &r.Checkout, &r.CreatedAt, &r.Active, &r.MinimumNights, &r.Strategy)
 		if err != nil {
 			return nil, err
 		}
@@ -429,7 +479,7 @@ func (s *Store) DeactivateRequest(ctx context.Context, id int64, userID string) 
 // Convenience: list active requests for a specific user
 func (s *Store) ListUserActiveRequests(ctx context.Context, userID string) ([]SchniffRequest, error) {
 	rows, err := s.DB.QueryContext(ctx, `
-		SELECT id, user_id, provider, campground_id, checkin, checkout, created_at, active
+		SELECT id, user_id, provider, campground_id, checkin, checkout, created_at, active, minimum_nights, strategy
 		FROM schniff_requests WHERE active=true AND user_id=?
 	`, userID)
 	if err != nil {
@@ -439,7 +489,7 @@ func (s *Store) ListUserActiveRequests(ctx context.Context, userID string) ([]Sc
 	var out []SchniffRequest
 	for rows.Next() {
 		var r SchniffRequest
-		err := rows.Scan(&r.ID, &r.UserID, &r.Provider, &r.CampgroundID, &r.Checkin, &r.Checkout, &r.CreatedAt, &r.Active)
+		err := rows.Scan(&r.ID, &r.UserID, &r.Provider, &r.CampgroundID, &r.Checkin, &r.Checkout, &r.CreatedAt, &r.Active, &r.MinimumNights, &r.Strategy)
 		if err != nil {
 			return nil, err
 		}
@@ -465,10 +515,10 @@ func (s *Store) DeactivateExpiredRequests(ctx context.Context) ([]SchniffRequest
 	// First, fetch and immediately deactivate the requests in a single atomic operation
 	// Use UPDATE ... RETURNING to get the deactivated records atomically
 	rows, err := tx.QueryContext(ctx, `
-		UPDATE schniff_requests 
-		SET active=false 
+		UPDATE schniff_requests
+		SET active=false
 		WHERE active=true AND (checkout < date('now') OR checkin < date('now'))
-		RETURNING id, user_id, provider, campground_id, checkin, checkout, created_at, active
+		RETURNING id, user_id, provider, campground_id, checkin, checkout, created_at, active, minimum_nights, strategy
 	`)
 	if err != nil {
 		return nil, err
@@ -479,7 +529,7 @@ func (s *Store) DeactivateExpiredRequests(ctx context.Context) ([]SchniffRequest
 	for rows.Next() {
 		var req SchniffRequest
 		err := rows.Scan(&req.ID, &req.UserID, &req.Provider, &req.CampgroundID,
-			&req.Checkin, &req.Checkout, &req.CreatedAt, &req.Active)
+			&req.Checkin, &req.Checkout, &req.CreatedAt, &req.Active, &req.MinimumNights, &req.Strategy)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/store_edge_test.go
+++ b/internal/db/store_edge_test.go
@@ -28,7 +28,9 @@ func TestDeactivateExpiredRequests_EdgeCases(t *testing.T) {
 			checkin     DATE NOT NULL,
 			checkout    DATE NOT NULL,
 			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
-			active      BOOLEAN DEFAULT TRUE
+			active      BOOLEAN DEFAULT TRUE,
+			minimum_nights INTEGER,
+			strategy    TEXT
 		)
 	`)
 	if err != nil {

--- a/internal/db/store_return_test.go
+++ b/internal/db/store_return_test.go
@@ -28,7 +28,9 @@ func TestDeactivateExpiredRequests_ReturnsCorrectRequests(t *testing.T) {
 			checkin     DATE NOT NULL,
 			checkout    DATE NOT NULL,
 			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
-			active      BOOLEAN DEFAULT TRUE
+			active      BOOLEAN DEFAULT TRUE,
+			minimum_nights INTEGER,
+			strategy    TEXT
 		)
 	`)
 	if err != nil {
@@ -79,9 +81,10 @@ func TestDeactivateExpiredRequests_ReturnsCorrectRequests(t *testing.T) {
 		if !expectedUsers[req.UserID] {
 			t.Errorf("Unexpected user ID in deactivated requests: %s", req.UserID)
 		}
-		// The returned requests should have Active=true (their state before deactivation)
-		if !req.Active {
-			t.Errorf("Returned request should have Active=true (original state), got Active=%v", req.Active)
+		// SQLite RETURNING on UPDATE yields the new row state, so deactivated
+		// requests come back with Active=false.
+		if req.Active {
+			t.Errorf("Returned request should have Active=false (post-update state), got Active=%v", req.Active)
 		}
 		if req.Provider == "" || req.CampgroundID == "" {
 			t.Errorf("Deactivated request missing required fields: Provider=%s, CampgroundID=%s", req.Provider, req.CampgroundID)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -29,7 +29,9 @@ func TestDeactivateExpiredRequests(t *testing.T) {
 			checkin     DATE NOT NULL,
 			checkout    DATE NOT NULL,
 			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
-			active      BOOLEAN DEFAULT TRUE
+			active      BOOLEAN DEFAULT TRUE,
+			minimum_nights INTEGER,
+			strategy    TEXT
 		)
 	`)
 	if err != nil {

--- a/internal/db/summary.go
+++ b/internal/db/summary.go
@@ -11,10 +11,10 @@ import (
 )
 
 type SummaryData struct {
-	Stats               DetailedSummaryStats
-	NotificationCounts  []UserCount // users who received hits in last 24h, count desc
-	ActiveCounts        []UserCount // users with active schniffs, count desc
-	TrackedCampgrounds  []string
+	Stats              DetailedSummaryStats
+	NotificationCounts []UserCount // users who received hits in last 24h, count desc
+	ActiveCounts       []UserCount // users with active schniffs, count desc
+	TrackedCampgrounds []string
 
 	// Optional: maps user_id -> display name. When nil/missing the embed
 	// falls back to <@user_id> mentions, which Discord renders as the

--- a/internal/manager/embed_test.go
+++ b/internal/manager/embed_test.go
@@ -56,20 +56,10 @@ func TestBuildDeactivationEmbed(t *testing.T) {
 		t.Errorf("Expected color %d, got %d", expectedColor, embed.Color)
 	}
 
-	// Check that we have fields for each request plus call-to-action field
-	expectedFieldCount := 3 // 2 requests + 1 call-to-action
+	// One field per deactivated request.
+	expectedFieldCount := 2
 	if len(embed.Fields) != expectedFieldCount {
 		t.Errorf("Expected %d fields, got %d", expectedFieldCount, len(embed.Fields))
-	}
-
-	// Check footer
-	if embed.Footer == nil {
-		t.Error("Expected footer to be present")
-	} else {
-		expectedFooterText := "💡 Click the /schniff command above to create new requests in a server where I'm present."
-		if embed.Footer.Text != expectedFooterText {
-			t.Errorf("Expected footer text '%s', got '%s'", expectedFooterText, embed.Footer.Text)
-		}
 	}
 
 	// Check timestamp format
@@ -90,22 +80,6 @@ func TestBuildDeactivationEmbed(t *testing.T) {
 
 		if !contains(firstField.Value, "🏕️ **Provider:** recreation_gov") {
 			t.Errorf("Expected provider information in field value, got '%s'", firstField.Value)
-		}
-	}
-
-	// Verify that the slash command mention is included in description
-	if !contains(embed.Description, "</schniff:0>") {
-		t.Errorf("Expected slash command mention in description, got '%s'", embed.Description)
-	}
-
-	// Verify the call-to-action field exists
-	if len(embed.Fields) >= 3 {
-		ctaField := embed.Fields[2] // Last field should be call-to-action
-		if ctaField.Name != "🚀 Create New Requests" {
-			t.Errorf("Expected call-to-action field name '🚀 Create New Requests', got '%s'", ctaField.Name)
-		}
-		if !contains(ctaField.Value, "</schniff:0>") {
-			t.Errorf("Expected slash command mention in call-to-action field, got '%s'", ctaField.Value)
 		}
 	}
 }
@@ -134,9 +108,9 @@ func TestBuildDeactivationEmbed_SingleRequest(t *testing.T) {
 		t.Errorf("Expected title '%s', got '%s'", expectedTitle, embed.Title)
 	}
 
-	// Should have exactly two fields (1 request + 1 call-to-action)
-	if len(embed.Fields) != 2 {
-		t.Errorf("Expected 2 fields, got %d", len(embed.Fields))
+	// Should have exactly one field (1 request).
+	if len(embed.Fields) != 1 {
+		t.Errorf("Expected 1 field, got %d", len(embed.Fields))
 	}
 }
 

--- a/internal/manager/fencepost_test.go
+++ b/internal/manager/fencepost_test.go
@@ -63,7 +63,7 @@ func TestGenerateNights_ThuFriDoesNotOverlapFriSun(t *testing.T) {
 	fri := day(2025, 8, 15)
 	sun := day(2025, 8, 17)
 
-	requested := generateNights(fri, sun) // {Fri, Sat}
+	requested := generateNights(fri, sun)  // {Fri, Sat}
 	campground := generateNights(thu, fri) // {Thu}
 
 	for _, want := range requested {

--- a/internal/manager/filters.go
+++ b/internal/manager/filters.go
@@ -1,0 +1,93 @@
+package manager
+
+import (
+	"sort"
+	"time"
+
+	"github.com/brensch/schniffer/internal/db"
+)
+
+// requestConditionsMet reports whether the currently-available campsites
+// satisfy the optional filters attached to the schniff request
+// (minimum_nights, strategy). A request with neither filter set always
+// passes.
+//
+// allAvailable should be the currently-available campsite/date pairs inside
+// the request's [Checkin, Checkout) window.
+func requestConditionsMet(req db.SchniffRequest, allAvailable []db.AvailabilityItem) bool {
+	hasMin := req.MinimumNights.Valid && req.MinimumNights.Int64 > 0
+	hasStrat := req.Strategy.Valid && req.Strategy.String != ""
+	if !hasMin && !hasStrat {
+		return true
+	}
+
+	// Group dates by campsite, normalized to day boundaries.
+	byCampsite := map[string][]time.Time{}
+	for _, it := range allAvailable {
+		d := normalizeDay(it.Date)
+		if d.Before(normalizeDay(req.Checkin)) || !d.Before(normalizeDay(req.Checkout)) {
+			continue
+		}
+		byCampsite[it.CampsiteID] = append(byCampsite[it.CampsiteID], d)
+	}
+
+	for _, dates := range byCampsite {
+		sort.Slice(dates, func(i, j int) bool { return dates[i].Before(dates[j]) })
+		if hasMin && !hasContiguousRun(dates, int(req.MinimumNights.Int64)) {
+			continue
+		}
+		if hasStrat && !campsiteMeetsStrategy(dates, req.Strategy.String) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// hasContiguousRun reports whether dates (sorted ascending, deduped or not)
+// contains a run of at least n consecutive days.
+func hasContiguousRun(dates []time.Time, n int) bool {
+	if n <= 0 {
+		return true
+	}
+	if len(dates) < n {
+		return false
+	}
+	run := 1
+	for i := 1; i < len(dates); i++ {
+		switch {
+		case dates[i].Equal(dates[i-1]):
+			// duplicate; ignore
+		case dates[i].Equal(dates[i-1].AddDate(0, 0, 1)):
+			run++
+			if run >= n {
+				return true
+			}
+		default:
+			run = 1
+		}
+	}
+	return run >= n
+}
+
+// campsiteMeetsStrategy applies the named strategy filter to a sorted set of
+// available nights for a single campsite. Unknown strategies fail closed.
+func campsiteMeetsStrategy(dates []time.Time, strategy string) bool {
+	switch strategy {
+	case db.StrategyFullWeekend:
+		// Need a Friday night (Fri) immediately followed by Saturday night
+		// (Sat) both available on the same campsite.
+		set := map[time.Time]bool{}
+		for _, d := range dates {
+			set[d] = true
+		}
+		for d := range set {
+			if d.Weekday() == time.Friday && set[d.AddDate(0, 0, 1)] {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/internal/manager/filters_test.go
+++ b/internal/manager/filters_test.go
@@ -1,0 +1,84 @@
+package manager
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/brensch/schniffer/internal/db"
+)
+
+func parseDay(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestRequestConditionsMet_NoFilters(t *testing.T) {
+	req := db.SchniffRequest{Checkin: parseDay("2026-05-12"), Checkout: parseDay("2026-05-15")}
+	if !requestConditionsMet(req, nil) {
+		t.Fatal("no filters should always pass even with empty availability")
+	}
+}
+
+func TestRequestConditionsMet_MinimumNights(t *testing.T) {
+	req := db.SchniffRequest{
+		Checkin:       parseDay("2026-05-12"),
+		Checkout:      parseDay("2026-05-15"),
+		MinimumNights: sql.NullInt64{Int64: 3, Valid: true},
+	}
+	// One campsite with only 2 consecutive nights → fails.
+	avail := []db.AvailabilityItem{
+		{CampsiteID: "A", Date: parseDay("2026-05-12")},
+		{CampsiteID: "A", Date: parseDay("2026-05-13")},
+	}
+	if requestConditionsMet(req, avail) {
+		t.Fatal("2 consecutive nights should not satisfy min_nights=3")
+	}
+	// Same campsite gets the 3rd consecutive night → passes.
+	avail = append(avail, db.AvailabilityItem{CampsiteID: "A", Date: parseDay("2026-05-14")})
+	if !requestConditionsMet(req, avail) {
+		t.Fatal("3 consecutive nights should satisfy min_nights=3")
+	}
+	// Split across two campsites → still fails (must be a single campsite).
+	avail = []db.AvailabilityItem{
+		{CampsiteID: "A", Date: parseDay("2026-05-12")},
+		{CampsiteID: "A", Date: parseDay("2026-05-13")},
+		{CampsiteID: "B", Date: parseDay("2026-05-14")},
+	}
+	if requestConditionsMet(req, avail) {
+		t.Fatal("availability split across campsites should not satisfy min_nights=3")
+	}
+}
+
+func TestRequestConditionsMet_FullWeekend(t *testing.T) {
+	// 2026-05-15 is a Friday.
+	req := db.SchniffRequest{
+		Checkin:  parseDay("2026-05-15"),
+		Checkout: parseDay("2026-05-18"),
+		Strategy: sql.NullString{String: db.StrategyFullWeekend, Valid: true},
+	}
+	// Only Saturday → fails.
+	avail := []db.AvailabilityItem{{CampsiteID: "A", Date: parseDay("2026-05-16")}}
+	if requestConditionsMet(req, avail) {
+		t.Fatal("Saturday only should not satisfy full_weekend")
+	}
+	// Fri + Sat on same campsite → passes.
+	avail = []db.AvailabilityItem{
+		{CampsiteID: "A", Date: parseDay("2026-05-15")},
+		{CampsiteID: "A", Date: parseDay("2026-05-16")},
+	}
+	if !requestConditionsMet(req, avail) {
+		t.Fatal("Fri+Sat should satisfy full_weekend")
+	}
+	// Fri and Sat split across campsites → fails (per-campsite check).
+	avail = []db.AvailabilityItem{
+		{CampsiteID: "A", Date: parseDay("2026-05-15")},
+		{CampsiteID: "B", Date: parseDay("2026-05-16")},
+	}
+	if requestConditionsMet(req, avail) {
+		t.Fatal("Fri+Sat split across campsites should not satisfy full_weekend")
+	}
+}

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -140,6 +140,25 @@ func (m *Manager) sendStateChangeNotification(
 		return false, nil
 	}
 
+	// Build the current availability context for the requested date range.
+	// We need this up front because the schniff's optional minimum_nights /
+	// strategy filters gate both the DM and the auto-booking call.
+	allAvailable, qerr := m.store.GetCurrentlyAvailableCampsites(ctx, req.Provider, req.CampgroundID, req.Checkin, req.Checkout)
+	if qerr != nil {
+		m.logger.Warn("get currently available campsites failed", slog.Any("err", qerr))
+	}
+
+	if !requestConditionsMet(req, allAvailable) {
+		m.logger.Info("schniff conditions not yet met; skipping notify+book",
+			slog.Int64("requestID", req.ID),
+			slog.String("userID", req.UserID),
+			slog.String("campgroundID", req.CampgroundID),
+			slog.Bool("hasMinNights", req.MinimumNights.Valid),
+			slog.Bool("hasStrategy", req.Strategy.Valid),
+		)
+		return false, nil
+	}
+
 	// Create DM channel only if we plan to send something.
 	channel, err := m.notifier.UserChannelCreate(req.UserID)
 	if err != nil {
@@ -153,12 +172,6 @@ func (m *Manager) sendStateChangeNotification(
 	// the hit notification.
 	if m.pool != nil && m.pool.HasUser(req.UserID) {
 		m.startBookingAttempt(ctx, req, newlyAvail, batchID, channel.ID)
-	}
-
-	// Build the current availability context for the requested date range.
-	allAvailable, qerr := m.store.GetCurrentlyAvailableCampsites(ctx, req.Provider, req.CampgroundID, req.Checkin, req.Checkout)
-	if qerr != nil {
-		m.logger.Warn("get currently available campsites failed", slog.Any("err", qerr))
 	}
 
 	byCampsite := groupAvailabilityByCampsite(allAvailable)

--- a/internal/manager/notifications_test.go
+++ b/internal/manager/notifications_test.go
@@ -94,23 +94,13 @@ func TestBuildNotificationEmbeds_NoCampsites(t *testing.T) {
 		provider,
 	)
 
-	if len(embeds) == 0 {
-		t.Fatalf("expected at least one embed with description header")
-	}
-	for _, e := range embeds {
-		if e.Description == "" {
-			t.Errorf("description should not be empty")
-		}
-		// No fields because no campsites
-		if len(e.Fields) != 1 {
-			// one "Remember" field is appended at the end of the last embed
-			// but since there are no campsite fields, it will be on the only embed
-			t.Logf("fields=%d (OK if 'Remember' was added)", len(e.Fields))
-		}
+	// Current builder returns nil when there is nothing to render.
+	if len(embeds) != 0 {
+		t.Fatalf("expected no embeds for empty stats, got %d", len(embeds))
 	}
 }
 
-func TestBuildNotificationEmbeds_RemovesCostAndRating_AndHasDivider(t *testing.T) {
+func TestBuildNotificationEmbeds_RemovesCostAndRating(t *testing.T) {
 	checkin := mustDate(2025, 8, 18)
 	checkout := checkin.AddDate(0, 0, 5)
 	provider := &mockProvider{}
@@ -128,19 +118,12 @@ func TestBuildNotificationEmbeds_RemovesCostAndRating_AndHasDivider(t *testing.T
 		t.Fatalf("expected embeds")
 	}
 
-	foundDivider := false
 	for _, e := range embeds {
 		for _, f := range e.Fields {
 			if containsAny(f.Value, "Cost:", "Rating:", "⭐") {
 				t.Fatalf("cost/rating must not be present; found in field: %q", f.Value)
 			}
-			if strings.Contains(f.Value, "────────────────────────────────────────") {
-				foundDivider = true
-			}
 		}
-	}
-	if !foundDivider {
-		t.Fatalf("expected divider line between campsites")
 	}
 }
 
@@ -167,12 +150,13 @@ func TestBuildNotificationEmbeds_SortsByDaysAvailableThenID(t *testing.T) {
 		t.Fatalf("expected embeds")
 	}
 
-	// The first campsite field should be csA (or csA part 1 of N if chunked)
+	// Top 3 by days available: csA (7), csC (7, sorted by ID tiebreak), csB (4).
+	// Fancy details mean field names are "Fancy Site csX", not "Campsite csX".
 	var firstField *discordgo.MessageEmbedField
 outer:
 	for _, e := range embeds {
 		for _, f := range e.Fields {
-			if strings.HasPrefix(f.Name, "Campsite ") {
+			if strings.HasPrefix(f.Name, "Fancy Site ") || strings.HasPrefix(f.Name, "Campsite ") {
 				firstField = f
 				break outer
 			}
@@ -181,17 +165,17 @@ outer:
 	if firstField == nil {
 		t.Fatalf("no campsite fields found")
 	}
-	if !strings.HasPrefix(firstField.Name, "Campsite csA") {
+	if !strings.Contains(firstField.Name, "csA") {
 		t.Fatalf("expected first campsite to be csA, got field name: %s", firstField.Name)
 	}
 }
 
-func TestBuildNotificationEmbeds_SplitsAcrossMultipleEmbeds_ByFieldCount(t *testing.T) {
+func TestBuildNotificationEmbeds_KeepsTopThree(t *testing.T) {
 	checkin := mustDate(2025, 8, 18)
 	checkout := checkin.AddDate(0, 0, 3)
 	provider := &mockProvider{}
 
-	// 60 campsites -> with 25 fields max per embed, should create at least 3 embeds
+	// Many campsites — current builder collapses to top 3 in a single embed.
 	stats := make([]manager.CampsiteStats, 0, 60)
 	for i := 0; i < 60; i++ {
 		id := fmt.Sprintf("cs%03d", i+1)
@@ -205,22 +189,23 @@ func TestBuildNotificationEmbeds_SplitsAcrossMultipleEmbeds_ByFieldCount(t *test
 		provider,
 	)
 
-	if len(embeds) < 3 {
-		t.Fatalf("expected >= 3 embeds, got %d", len(embeds))
+	if len(embeds) != 1 {
+		t.Fatalf("expected exactly 1 embed, got %d", len(embeds))
 	}
-	for i, e := range embeds {
-		if len(e.Fields) > 25 {
-			t.Fatalf("embed %d exceeds 25 fields: %d", i, len(e.Fields))
-		}
+	// 3 campsite fields + 1 Important Information field.
+	if got := len(embeds[0].Fields); got != 4 {
+		t.Fatalf("expected 4 fields (3 campsites + info), got %d", got)
 	}
 }
 
-func TestBuildNotificationEmbeds_ChunksLongFieldValues_AndDoesNotTruncate(t *testing.T) {
+func TestBuildNotificationEmbeds_LongDateListIsCapped(t *testing.T) {
 	checkin := mustDate(2025, 8, 18)
 	checkout := checkin.AddDate(0, 0, 300)
 	provider := &mockProvider{}
 
-	// Single campsite with 200+ dates -> field value should exceed 1024 and be chunked into multiple fields
+	// Single campsite with 200 available dates — current builder caps the
+	// rendered list at 20 dates and appends an "…and N more" note rather
+	// than chunking across fields.
 	longDates := genDates(checkin, 200)
 	stats := []manager.CampsiteStats{
 		makeStats(300, "csLONG", longDates, true),
@@ -237,38 +222,19 @@ func TestBuildNotificationEmbeds_ChunksLongFieldValues_AndDoesNotTruncate(t *tes
 		t.Fatalf("expected embeds")
 	}
 
-	// Collect fields for this campsite
-	var parts []*discordgo.MessageEmbedField
+	var siteField *discordgo.MessageEmbedField
 	for _, e := range embeds {
 		for _, f := range e.Fields {
-			if strings.HasPrefix(f.Name, "Campsite csLONG") {
-				parts = append(parts, f)
+			if strings.Contains(f.Name, "csLONG") {
+				siteField = f
 			}
 		}
 	}
-	if len(parts) < 2 {
-		t.Fatalf("expected multiple chunked fields for csLONG, got %d", len(parts))
+	if siteField == nil {
+		t.Fatalf("csLONG field missing")
 	}
-	for i, p := range parts {
-		if len(p.Value) == 0 {
-			t.Fatalf("part %d empty", i)
-		}
-		if len(p.Value) > 1024 {
-			t.Fatalf("part %d exceeds 1024 chars; got %d", i, len(p.Value))
-		}
-	}
-
-	// Ensure some tail dates are present (no truncation of the list overall)
-	lastDateStr := longDates[len(longDates)-1].Format("2006-01-02")
-	foundLast := false
-	for _, p := range parts {
-		if strings.Contains(p.Value, lastDateStr) {
-			foundLast = true
-			break
-		}
-	}
-	if !foundLast {
-		t.Fatalf("expected last date %s to appear across chunks", lastDateStr)
+	if !strings.Contains(siteField.Value, "…and 180 more") {
+		t.Fatalf("expected truncation note in field value, got: %q", siteField.Value)
 	}
 }
 
@@ -307,11 +273,12 @@ func TestBuildNotificationEmbeds_EquipmentNotTruncated(t *testing.T) {
 	checkout := checkin.AddDate(0, 0, 5)
 	provider := &mockProvider{}
 
-	// Large equipment list should not be truncated by builder
+	// Large equipment list should not be truncated by builder.
+	equipment := []string{"Tent", "RV", "Trailer", "Van", "Car", "Bike", "Boat", "Kayak", "Motorcycle", "Foot"}
 	dets := db.CampsiteDetails{
 		Name:         "Monster Equip Site",
 		Type:         "Tent/RV",
-		Equipment:    []string{"Tent", "RV", "Trailer", "Van", "Car", "Bike", "Boat", "Kayak", "Motorcycle", "Foot"},
+		Equipment:    equipment,
 		CostPerNight: 999, // ignored
 		Rating:       5,   // ignored
 	}
@@ -335,16 +302,17 @@ func TestBuildNotificationEmbeds_EquipmentNotTruncated(t *testing.T) {
 	if len(embeds) == 0 {
 		t.Fatalf("expected embeds")
 	}
+	want := strings.Join(equipment, ", ")
 	ok := false
 	for _, e := range embeds {
 		for _, f := range e.Fields {
-			if strings.Contains(f.Value, "Equipment: Tent, RV, Trailer, Van, Car, Bike, Boat, Kayak, Motorcycle, Foot") {
+			if strings.Contains(f.Value, want) {
 				ok = true
 			}
 		}
 	}
 	if !ok {
-		t.Fatalf("expected full equipment list present without truncation")
+		t.Fatalf("expected full equipment list %q present without truncation", want)
 	}
 }
 
@@ -529,6 +497,12 @@ func TestBuildNotificationEmbed_Suite_Smoke(t *testing.T) {
 				tc.campsiteStats,
 				tc.provider,
 			)
+			if len(tc.campsiteStats) == 0 {
+				if len(embeds) != 0 {
+					t.Fatalf("expected no embeds for empty stats, got %d", len(embeds))
+				}
+				return
+			}
 			if len(embeds) == 0 {
 				t.Fatalf("expected embeds")
 			}

--- a/internal/manager/parallelism_test.go
+++ b/internal/manager/parallelism_test.go
@@ -47,8 +47,8 @@ func (f *fakeProvider) FetchAllCampgrounds(context.Context) ([]providers.Campgro
 func (f *fakeProvider) FetchCampsites(context.Context, string) ([]providers.CampsiteInfo, error) {
 	return nil, nil
 }
-func (f *fakeProvider) CampsiteURL(string, string) string  { return "" }
-func (f *fakeProvider) CampgroundURL(string) string        { return "" }
+func (f *fakeProvider) CampsiteURL(string, string) string { return "" }
+func (f *fakeProvider) CampgroundURL(string) string       { return "" }
 func (f *fakeProvider) PlanBuckets(d []time.Time) []providers.DateRange {
 	if len(d) == 0 {
 		return nil

--- a/internal/providers/amenities_test.go
+++ b/internal/providers/amenities_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestExploreAmenities(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live ReserveCalifornia call in -short mode")
+	}
 	// Create ReserveCalifornia provider
 	provider := NewReserveCalifornia()
 

--- a/internal/providers/multi_amenities_test.go
+++ b/internal/providers/multi_amenities_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestMultipleCampgroundAmenities(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live ReserveCalifornia call in -short mode")
+	}
 	provider := NewReserveCalifornia()
 	ctx := context.Background()
 

--- a/internal/providers/recreation_gov_test.go
+++ b/internal/providers/recreation_gov_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -21,8 +22,12 @@ func newRecreationGovForTest(t *testing.T, srv *httptest.Server) *RecreationGov 
 }
 
 func TestRecreationGov_FetchAvailability_URLQueryEncoded(t *testing.T) {
-	// Arrange a fake API that captures the raw query string.
-	var captured []string
+	// Arrange a fake API that captures the raw query string. The provider
+	// fans out month buckets concurrently, so guard the slice.
+	var (
+		mu       sync.Mutex
+		captured []string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/api/camps/availability/campground/") {
 			http.NotFound(w, r)
@@ -32,7 +37,9 @@ func TestRecreationGov_FetchAvailability_URLQueryEncoded(t *testing.T) {
 			http.Error(w, "bad path", http.StatusBadRequest)
 			return
 		}
+		mu.Lock()
 		captured = append(captured, r.URL.RawQuery)
+		mu.Unlock()
 		// Minimal valid body
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"campsites": map[string]any{}})
@@ -49,22 +56,25 @@ func TestRecreationGov_FetchAvailability_URLQueryEncoded(t *testing.T) {
 		t.Fatalf("FetchAvailability returned error: %v", err)
 	}
 
-	if len(captured) == 0 {
+	mu.Lock()
+	got := append([]string(nil), captured...)
+	mu.Unlock()
+	if len(got) == 0 {
 		t.Fatalf("server did not receive any requests")
 	}
 	// Verify each query contains properly encoded start_date; plus and colon should be percent-encoded.
-	for _, raw := range captured {
+	for _, raw := range got {
 		q, _ := url.ParseQuery(raw)
-		got := q.Get("start_date")
-		if got == "" {
+		sd := q.Get("start_date")
+		if sd == "" {
 			t.Fatalf("start_date missing from query: %q", raw)
 		}
 		if strings.ContainsAny(raw, "+ :") {
 			t.Fatalf("query appears not encoded: %q", raw)
 		}
 		// Check format ends with Z and has milliseconds
-		if !strings.HasSuffix(got, "Z") || len(got) < len("2006-01-02T15:04:05.000Z") {
-			t.Fatalf("unexpected start_date format: %q", got)
+		if !strings.HasSuffix(sd, "Z") || len(sd) < len("2006-01-02T15:04:05.000Z") {
+			t.Fatalf("unexpected start_date format: %q", sd)
 		}
 	}
 }

--- a/internal/providers/reservecalifornia_integration_test.go
+++ b/internal/providers/reservecalifornia_integration_test.go
@@ -24,8 +24,8 @@ func TestReserveCalifornia_Integration_GridEndpoint(t *testing.T) {
 	// Composite ID format: parentID-facilityID
 	campgroundID := "76-357"
 
-	start := time.Now().AddDate(0, 0, 7)  // One week from now
-	end := time.Now().AddDate(0, 0, 14)   // Two weeks from now
+	start := time.Now().AddDate(0, 0, 7) // One week from now
+	end := time.Now().AddDate(0, 0, 14)  // Two weeks from now
 
 	availability, err := provider.FetchAvailability(ctx, campgroundID, start, end)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds optional `minimum_nights` and `strategy` (currently `full_weekend`) filters to `/schniff add` and `/schniff add-bulk`. Notifications and warm-pool auto-booking only fire when a single campsite satisfies the conditions inside the schniff window.
- Fixes stale DB and manager tests that referenced behaviour that no longer exists (RETURNING semantics, simplified embed builders).
- Skips live ReserveCalifornia tests under `-short` so the suite stops timing out on the network.
- Adds `.github/workflows/ci.yml` running gofmt, `go vet`, and `go test -short -race -timeout 5m` on PRs and main pushes.
- Runs `gofmt -w` across `cmd/`, `internal/`, `proxy/`.

## How the filters work
- `minimum_nights`: integer 1..N where N = checkout − checkin (fenceposts: `2026-05-12` → `2026-05-15` ⇒ 3). Autocomplete lists `N, N-1, …, 1`. Rejected with an error if outside that range.
- `strategy`: Discord choice list, currently just `full_weekend` (Fri night + Sat night both free on the same campsite). Unknown values rejected.
- Gating happens in `sendStateChangeNotification` before any DM or `HoldCampsite` call, so notify and book are filtered together.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short -race -count=1 -timeout 5m ./...` (all green locally)
- [x] `gofmt -l cmd internal proxy` (clean)
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)