### PR TITLE
fix(bot): cap minimum_nights autocomplete at typed date span

### DIFF
--- a/internal/bot/handler_filters.go
+++ b/internal/bot/handler_filters.go
@@ -19,8 +19,10 @@ func strategyChoices() []*discordgo.ApplicationCommandOptionChoice {
 }
 
 // autocompleteMinimumNights suggests night counts based on the user's
-// currently-typed checkin/checkout. Top option is the full span, descending
-// down to 1.
+// currently-typed checkin/checkout. The largest suggestion is the span between
+// the two dates so users can't pick a value that's guaranteed to never fire.
+// When the dates aren't both valid yet, returns a single hint instead of a
+// misleading numeric range.
 func autocompleteMinimumNights(opts []*discordgo.ApplicationCommandInteractionDataOption) []*discordgo.ApplicationCommandOptionChoice {
 	var checkin, checkout string
 	for _, o := range opts {
@@ -31,17 +33,26 @@ func autocompleteMinimumNights(opts []*discordgo.ApplicationCommandInteractionDa
 			checkout = o.StringValue()
 		}
 	}
-	span := 0
-	if checkin != "" && checkout != "" {
-		start, end, err := parseDates(checkin, checkout)
-		if err == nil && end.After(start) {
-			span = int(end.Sub(start).Hours() / 24)
-		}
+	if checkin == "" || checkout == "" {
+		return []*discordgo.ApplicationCommandOptionChoice{{
+			Name:  "Enter checkin and checkout first to see options",
+			Value: 1,
+		}}
 	}
-	if span <= 0 {
-		// Fall back to a small static range so the suggestion list is never empty.
-		span = 7
+	start, end, err := parseDates(checkin, checkout)
+	if err != nil {
+		return []*discordgo.ApplicationCommandOptionChoice{{
+			Name:  fmt.Sprintf("Use YYYY-MM-DD for checkin/checkout (got %q / %q)", checkin, checkout),
+			Value: 1,
+		}}
 	}
+	if !end.After(start) {
+		return []*discordgo.ApplicationCommandOptionChoice{{
+			Name:  fmt.Sprintf("checkout (%s) must be after checkin (%s)", checkout, checkin),
+			Value: 1,
+		}}
+	}
+	span := int(end.Sub(start).Hours() / 24)
 	if span > 25 {
 		span = 25 // Discord limit
 	}
@@ -67,14 +78,18 @@ func parseScheduleFilters(opts map[string]*discordgo.ApplicationCommandInteracti
 	var strat sql.NullString
 
 	nights := int(end.Sub(start).Hours() / 24)
+	const layout = "2006-01-02"
 
 	if o, ok := opts["minimum_nights"]; ok && o != nil {
 		v := o.IntValue()
 		if v < 1 {
-			return minN, strat, "minimum_nights must be at least 1"
+			return minN, strat, fmt.Sprintf("minimum_nights must be at least 1 (got %d)", v)
 		}
 		if v > int64(nights) {
-			return minN, strat, fmt.Sprintf("minimum_nights (%d) cannot exceed the %d night window", v, nights)
+			return minN, strat, fmt.Sprintf(
+				"minimum_nights=%d cannot exceed the %d-night window between checkin %s and checkout %s — pick a value between 1 and %d, or widen the date range",
+				v, nights, start.Format(layout), end.Format(layout), nights,
+			)
 		}
 		minN = sql.NullInt64{Int64: v, Valid: true}
 	}
@@ -83,10 +98,36 @@ func parseScheduleFilters(opts map[string]*discordgo.ApplicationCommandInteracti
 		s := strings.TrimSpace(o.StringValue())
 		if s != "" {
 			if !db.IsValidStrategy(s) {
-				return minN, strat, fmt.Sprintf("unknown strategy %q (valid: %s)", s, strings.Join(db.ValidStrategies, ", "))
+				return minN, strat, fmt.Sprintf(
+					"unknown strategy %q — valid options: %s",
+					s, strings.Join(db.ValidStrategies, ", "),
+				)
+			}
+			if s == db.StrategyFullWeekend {
+				if !windowContainsFriSat(start, end) {
+					return minN, strat, fmt.Sprintf(
+						"strategy=%s requires the window %s → %s to include both a Friday and the following Saturday night — none found in this range",
+						s, start.Format(layout), end.Format(layout),
+					)
+				}
 			}
 			strat = sql.NullString{String: s, Valid: true}
 		}
 	}
 	return minN, strat, ""
+}
+
+// windowContainsFriSat reports whether [start, end) covers at least one Fri+Sat
+// night pair (i.e. a Friday night where the following Saturday night is also
+// inside the window).
+func windowContainsFriSat(start, end time.Time) bool {
+	for d := start; d.Before(end); d = d.AddDate(0, 0, 1) {
+		if d.Weekday() == time.Friday {
+			sat := d.AddDate(0, 0, 1)
+			if sat.Before(end) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- `autocompleteMinimumNights` now requires both checkin and checkout to parse and caps suggestions at the actual span, so users can't pick a value larger than the window that's guaranteed to never fire.
- When dates are missing/malformed it returns a single hint choice instead of a misleading 1–7 fallback that ignored typed input.
- `parseScheduleFilters` validation errors now quote the offending value, the typed dates, and the valid range; `full_weekend` is rejected upfront if the window doesn't contain a Fri+Sat night pair.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/bot/... ./internal/manager/...`
- [ ] Manually trigger the Discord autocomplete with no dates, with one date, with malformed dates, and with a valid range, confirming the suggestions match.
- [ ] Submit `/schniff add` with `minimum_nights` greater than the span and confirm the new error message references the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)