### PR TITLE
chore(deploy): drop sqlite backup step

### DIFF
--- a/.github/workflows/deploy-schniffer.yml
+++ b/.github/workflows/deploy-schniffer.yml
@@ -15,7 +15,6 @@ concurrency:
 env:
   DATA_DIR: /home/brensch/schniffdata
   PROFILES_DIR: /home/brensch/schniffprofiles
-  BACKUPS:  /home/brensch/schniff-backups
   COMPOSE_PROJECT_NAME: schniffer
 
 jobs:
@@ -37,14 +36,6 @@ jobs:
           # so the host dir needs to be writable by root in container; bind
           # mounts preserve host ownership, so we just ensure it exists.
           ls -la "$PROFILES_DIR" || true
-
-      - name: Backup sqlite
-        run: |
-          mkdir -p "$BACKUPS"
-          ts=$(date +%Y%m%d-%H%M%S)
-          cp "$DATA_DIR/schniffer.sqlite" "$BACKUPS/schniffer.sqlite.$ts"
-          ls -1t "$BACKUPS"/schniffer.sqlite.* | tail -n +11 | xargs -r rm -f
-          ls -lh "$BACKUPS" | tail -5
 
       - name: Build and (re)start container
         env:


### PR DESCRIPTION
## Summary
- Removes the **Backup sqlite** step from `deploy-schniffer.yml` and the now-unused `BACKUPS` env var.
- Stops the self-hosted runner from accumulating ~8 GB of `.sqlite` snapshots in `/home/brensch/schniff-backups/` on every push to main.

## Why
The runner just filled `/` to 100%, which crash-looped the GitHub Actions runner. While poking around I noticed:
- the workflow `cp`-copies an ~810 MB SQLite file on every deploy,
- retains the most recent 10 (so steady-state ~8 GB),
- nobody has referred back to one in months.

If we want real point-in-time recovery for the bot DB we should run a proper streaming backup (Litestream → GCS) rather than copying-on-deploy.

## Cleanup already done on the runner host
- `rm -rf /home/brensch/schniff-backups` (8 GB freed)
- `/home/brensch/nem` LV removed and merged into root LV (~370 GB added to `/`)
- root is now 466 GB / 78 GB used / 369 GB free.

## Test plan
- [ ] CI workflow runs green on this PR (gofmt + vet + test).
- [ ] After merge: `Deploy schniffer` runs, no `Backup sqlite` step appears, container `schniffer-bot` ends `running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)