### PR TITLE
feat(bot): add /schniff group list and remove, compact list output

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -163,6 +163,12 @@ func (b *Bot) registerCommands() {
 					{Name: "strategy", Type: discordgo.ApplicationCommandOptionString, Required: false, Description: "Extra condition before notifying/booking", Choices: strategyChoices()},
 				}},
 				{Name: "map", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Open map to create groups or quickly see availability at a site."},
+				{Name: "group", Type: discordgo.ApplicationCommandOptionSubCommandGroup, Description: "Manage saved campground groups", Options: []*discordgo.ApplicationCommandOption{
+					{Name: "list", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "List your campground groups and their sites"},
+					{Name: "remove", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove a campground group", Options: []*discordgo.ApplicationCommandOption{
+						{Name: "group", Type: discordgo.ApplicationCommandOptionString, Required: true, Description: "Select group", Autocomplete: true},
+					}},
+				}},
 				{Name: "remove", Type: discordgo.ApplicationCommandOptionSubCommand, Description: "Remove a single schniff by id.", Options: []*discordgo.ApplicationCommandOption{
 					{Name: "ids", Type: discordgo.ApplicationCommandOptionInteger, Required: true, Description: "Request ID to remove", Autocomplete: true},
 				}},
@@ -214,6 +220,10 @@ func (b *Bot) handleAutocomplete(s *discordgo.Session, i *discordgo.InteractionC
 		return
 	}
 	sub := data.Options[0]
+	// If this is a subcommand group, descend into the inner subcommand.
+	if sub.Type == discordgo.ApplicationCommandOptionSubCommandGroup && len(sub.Options) > 0 {
+		sub = sub.Options[0]
+	}
 	focused := findFocusedOption(sub.Options)
 	if focused == nil {
 		return
@@ -260,6 +270,17 @@ func (b *Bot) handleApplicationCommand(s *discordgo.Session, i *discordgo.Intera
 		b.handleAddBulkCommand(s, i, sub)
 	case "map":
 		b.handleLinkMapCommand(s, i, sub)
+	case "group":
+		if len(sub.Options) == 0 {
+			return
+		}
+		inner := sub.Options[0]
+		switch inner.Name {
+		case "list":
+			b.handleGroupListCommand(s, i, inner)
+		case "remove":
+			b.handleGroupRemoveCommand(s, i, inner)
+		}
 	case "remove":
 		b.handleRemoveCommand(s, i, sub)
 	case "remove-all":

--- a/internal/bot/handler_group.go
+++ b/internal/bot/handler_group.go
@@ -1,0 +1,110 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func (b *Bot) handleGroupListCommand(s *discordgo.Session, i *discordgo.InteractionCreate, _ *discordgo.ApplicationCommandInteractionDataOption) {
+	uid := getUserID(i)
+	groups, err := b.store.GetUserGroups(context.Background(), uid)
+	if err != nil {
+		respond(s, i, "error: "+err.Error())
+		return
+	}
+	if len(groups) == 0 {
+		respond(s, i, "you have no groups. Run `/schniff map` to create one.")
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Flags: 1 << 6},
+	})
+
+	ctx := context.Background()
+	const maxDesc = 3800
+	desc := strings.Builder{}
+	embeds := make([]*discordgo.MessageEmbed, 0)
+	flush := func() {
+		if desc.Len() == 0 {
+			return
+		}
+		embeds = append(embeds, &discordgo.MessageEmbed{
+			Description: desc.String(),
+			Timestamp:   time.Now().Format(time.RFC3339),
+		})
+		desc.Reset()
+	}
+
+	for _, g := range groups {
+		block := strings.Builder{}
+		block.WriteString(fmt.Sprintf("**%s** · `id %d` · %d site%s\n",
+			sanitizeGenericText(g.Name), g.ID, len(g.Campgrounds), plural(len(g.Campgrounds))))
+		for _, cg := range g.Campgrounds {
+			name := b.formatCampgroundWithLink(ctx, cg.Provider, cg.CampgroundID, cg.CampgroundID)
+			block.WriteString("• " + name + "\n")
+		}
+		block.WriteString("\n")
+
+		if desc.Len()+block.Len() > maxDesc {
+			flush()
+		}
+		desc.WriteString(block.String())
+	}
+	flush()
+
+	// Send in batches of up to 10 embeds per message.
+	for start := 0; start < len(embeds); start += 10 {
+		end := start + 10
+		if end > len(embeds) {
+			end = len(embeds)
+		}
+		_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds[start:end], Flags: 1 << 6})
+		if err != nil {
+			b.logger.Warn("group list followup send failed", "err", err)
+		}
+	}
+}
+
+func (b *Bot) handleGroupRemoveCommand(s *discordgo.Session, i *discordgo.InteractionCreate, sub *discordgo.ApplicationCommandInteractionDataOption) {
+	uid := getUserID(i)
+	opts := optMap(sub.Options)
+	groupResponse, ok := opts["group"]
+	if !ok || groupResponse == nil {
+		respond(s, i, "group selection is required")
+		return
+	}
+	val := groupResponse.StringValue()
+	if val == noGroupsFound {
+		respond(s, i, "bro you're not meant to click that option.")
+		return
+	}
+	parts := strings.SplitN(val, "||", 2)
+	if len(parts) != 2 {
+		respond(s, i, "invalid group selection")
+		return
+	}
+	groupID, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		respond(s, i, "invalid group ID")
+		return
+	}
+	if err := b.store.DeleteGroup(context.Background(), groupID, uid); err != nil {
+		respond(s, i, "error: "+err.Error())
+		return
+	}
+	respond(s, i, fmt.Sprintf("removed group '%s'", parts[1]))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/bot/handler_list.go
+++ b/internal/bot/handler_list.go
@@ -60,47 +60,63 @@ func (b *Bot) handleListCommand(s *discordgo.Session, i *discordgo.InteractionCr
 		Data: &discordgo.InteractionResponseData{Flags: 1 << 6},
 	})
 
-	// Build embeds (one per schniff) to ensure links render and to stay within limits
+	// Build a compact, mobile-friendly list: two lines per schniff, many per embed.
 	weekday := func(t time.Time) string { return t.Format("Mon") }
-	embeds := make([]*discordgo.MessageEmbed, 0, len(items))
-	for _, it := range items {
-		// display name with link
-		name := b.formatCampgroundWithLink(context.Background(), it.provider, it.campgroundID, it.campgroundID)
+	const maxDesc = 3800
+	desc := strings.Builder{}
+	embeds := make([]*discordgo.MessageEmbed, 0)
+	flush := func() {
+		if desc.Len() == 0 {
+			return
+		}
+		embeds = append(embeds, &discordgo.MessageEmbed{
+			Description: desc.String(),
+			Timestamp:   time.Now().Format(time.RFC3339),
+		})
+		desc.Reset()
+	}
 
+	for _, it := range items {
+		name := b.formatCampgroundWithLink(context.Background(), it.provider, it.campgroundID, it.campgroundID)
 		nights := int(it.checkout.Sub(it.checkin).Hours() / 24)
-		// total checks for this campground since the request was created
 		totalChecks, err := b.store.CountLookupsSinceTime(context.Background(), it.provider, it.campgroundID, it.created)
 		if err != nil {
 			b.logger.Warn("count request checks failed", "err", err)
 			totalChecks = 0
 		}
-		// Build description in the required format but inside an embed
-		desc := strings.Builder{}
-		desc.WriteString(name + "\n")
-		desc.WriteString(fmt.Sprintf("%s (%s) -> %s (%s) (%d nights)\n", it.checkin.Format("2006-01-02"), weekday(it.checkin), it.checkout.Format("2006-01-02"), weekday(it.checkout), nights))
+
+		block := strings.Builder{}
+		block.WriteString(fmt.Sprintf("**%s** · `#%d`\n", name, it.id))
+		// Compact details line, separator-delimited so it wraps cleanly on mobile.
+		bits := []string{
+			fmt.Sprintf("%s %s → %s %s",
+				it.checkin.Format("2006-01-02"), weekday(it.checkin),
+				it.checkout.Format("2006-01-02"), weekday(it.checkout)),
+			fmt.Sprintf("%dn", nights),
+		}
 		if it.minimumNights.Valid {
-			desc.WriteString(fmt.Sprintf("minimum nights: %d\n", it.minimumNights.Int64))
+			bits = append(bits, fmt.Sprintf("min %d", it.minimumNights.Int64))
 		}
 		if it.strategy.Valid && it.strategy.String != "" {
-			desc.WriteString(fmt.Sprintf("strategy: %s\n", it.strategy.String))
+			bits = append(bits, it.strategy.String)
 		}
-		desc.WriteString(fmt.Sprintf("total api calls: %d\n", totalChecks))
+		bits = append(bits, fmt.Sprintf("%d checks", totalChecks))
+		block.WriteString(strings.Join(bits, " · "))
+		block.WriteString("\n\n")
 
-		embeds = append(embeds, &discordgo.MessageEmbed{
-			Description: desc.String(),
-			Timestamp:   time.Now().Format(time.RFC3339),
-		})
-		// Send in batches of up to 10 embeds per message to fit Discord limits
-		if len(embeds) == 10 {
-			_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds, Flags: 1 << 6})
-			if err != nil {
-				b.logger.Warn("state followup send failed", "err", err)
-			}
-			embeds = nil
+		if desc.Len()+block.Len() > maxDesc {
+			flush()
 		}
+		desc.WriteString(block.String())
 	}
-	if len(embeds) > 0 {
-		_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds, Flags: 1 << 6})
+	flush()
+
+	for start := 0; start < len(embeds); start += 10 {
+		end := start + 10
+		if end > len(embeds) {
+			end = len(embeds)
+		}
+		_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds[start:end], Flags: 1 << 6})
 		if err != nil {
 			b.logger.Warn("state followup send failed", "err", err)
 		}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1708,6 +1708,21 @@ func (s *Store) GetGroup(ctx context.Context, groupID int64, userID string) (*Gr
 	return &group, nil
 }
 
+func (s *Store) DeleteGroup(ctx context.Context, groupID int64, userID string) error {
+	res, err := s.DB.ExecContext(ctx, `DELETE FROM groups WHERE id = ? AND user_id = ?`, groupID, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete group: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return errors.New("group not found")
+	}
+	return nil
+}
+
 // GetCampgroundsByProvider retrieves all campgrounds for a specific provider
 func (s *Store) GetCampgroundsByProvider(ctx context.Context, provider string) ([]Campground, error) {
 	rows, err := s.DB.QueryContext(ctx, `


### PR DESCRIPTION
## Summary
- New `/schniff group list` shows each saved group with its campgrounds (linked).
- New `/schniff group remove <group>` deletes a group (autocompletes the user's groups).
- Both list commands (`/schniff list` and `/schniff group list`) now use a denser two-line-per-item layout — same data, less space, still renders cleanly on mobile.

## Test plan
- [ ] `/schniff group list` with 0, 1, and many groups
- [ ] `/schniff group remove` removes the selected group and autocompletes the user's groups only
- [ ] `/schniff list` displays compact format on mobile and desktop
- [ ] Removing a group does not affect existing schniff requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)