### PR TITLE
feat(bot): hashed-color embed cards for /schniff list and group list

### DIFF
--- a/internal/bot/handler_group.go
+++ b/internal/bot/handler_group.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -28,38 +27,20 @@ func (b *Bot) handleGroupListCommand(s *discordgo.Session, i *discordgo.Interact
 	})
 
 	ctx := context.Background()
-	const maxDesc = 3800
-	desc := strings.Builder{}
-	embeds := make([]*discordgo.MessageEmbed, 0)
-	flush := func() {
-		if desc.Len() == 0 {
-			return
+	embeds := make([]*discordgo.MessageEmbed, 0, len(groups))
+	for _, g := range groups {
+		lines := make([]string, 0, len(g.Campgrounds))
+		for _, cg := range g.Campgrounds {
+			lines = append(lines, "▸ "+b.formatCampgroundWithLink(ctx, cg.Provider, cg.CampgroundID, cg.CampgroundID))
 		}
 		embeds = append(embeds, &discordgo.MessageEmbed{
-			Description: desc.String(),
-			Timestamp:   time.Now().Format(time.RFC3339),
+			Author:      &discordgo.MessageEmbedAuthor{Name: "Group: " + g.Name},
+			Description: strings.Join(lines, "\n"),
+			Color:       colorFromName(g.Name),
+			Footer:      &discordgo.MessageEmbedFooter{Text: fmt.Sprintf("%d site%s", len(g.Campgrounds), plural(len(g.Campgrounds)))},
 		})
-		desc.Reset()
 	}
 
-	for _, g := range groups {
-		block := strings.Builder{}
-		block.WriteString(fmt.Sprintf("**%s** · `id %d` · %d site%s\n",
-			sanitizeGenericText(g.Name), g.ID, len(g.Campgrounds), plural(len(g.Campgrounds))))
-		for _, cg := range g.Campgrounds {
-			name := b.formatCampgroundWithLink(ctx, cg.Provider, cg.CampgroundID, cg.CampgroundID)
-			block.WriteString("• " + name + "\n")
-		}
-		block.WriteString("\n")
-
-		if desc.Len()+block.Len() > maxDesc {
-			flush()
-		}
-		desc.WriteString(block.String())
-	}
-	flush()
-
-	// Send in batches of up to 10 embeds per message.
 	for start := 0; start < len(embeds); start += 10 {
 		end := start + 10
 		if end > len(embeds) {

--- a/internal/bot/handler_list.go
+++ b/internal/bot/handler_list.go
@@ -11,10 +11,9 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-// handleListCommand prints, for each active schniff owned by the user:
-// - number of checks in the last 24 hours (for that campground)
-// - number of notifications in the last 24 hours (for that request)
-// - latest per-date availability counts within the schniff date range
+// handleListCommand renders one embed per active schniff, with the campground
+// name as a clickable author header and a sidebar color hashed from the
+// parent-park name so campgrounds in the same park share a color.
 func (b *Bot) handleListCommand(s *discordgo.Session, i *discordgo.InteractionCreate, _ *discordgo.ApplicationCommandInteractionDataOption) {
 	uid := getUserID(i)
 	reqs, err := b.store.ListUserActiveRequests(context.Background(), uid)
@@ -22,7 +21,6 @@ func (b *Bot) handleListCommand(s *discordgo.Session, i *discordgo.InteractionCr
 		respond(s, i, "error: "+err.Error())
 		return
 	}
-	// Filter to user and keep stable order by created_at via ID ascending
 	type item struct {
 		id                int64
 		provider          string
@@ -54,46 +52,42 @@ func (b *Bot) handleListCommand(s *discordgo.Session, i *discordgo.InteractionCr
 	}
 	sort.Slice(items, func(a, b int) bool { return items[a].id < items[b].id })
 
-	// We'll defer initial ack for longer responses (ephemeral)
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{Flags: 1 << 6},
 	})
 
-	// Build a compact, mobile-friendly list: two lines per schniff, many per embed.
-	weekday := func(t time.Time) string { return t.Format("Mon") }
-	const maxDesc = 3800
-	desc := strings.Builder{}
-	embeds := make([]*discordgo.MessageEmbed, 0)
-	flush := func() {
-		if desc.Len() == 0 {
+	ctx := context.Background()
+	embeds := make([]*discordgo.MessageEmbed, 0, len(items))
+	flushBatch := func() {
+		if len(embeds) == 0 {
 			return
 		}
-		embeds = append(embeds, &discordgo.MessageEmbed{
-			Description: desc.String(),
-			Timestamp:   time.Now().Format(time.RFC3339),
-		})
-		desc.Reset()
+		_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds, Flags: 1 << 6})
+		if err != nil {
+			b.logger.Warn("list followup send failed", "err", err)
+		}
+		embeds = embeds[:0]
 	}
 
 	for _, it := range items {
-		name := b.formatCampgroundWithLink(context.Background(), it.provider, it.campgroundID, it.campgroundID)
-		nights := int(it.checkout.Sub(it.checkin).Hours() / 24)
-		totalChecks, err := b.store.CountLookupsSinceTime(context.Background(), it.provider, it.campgroundID, it.created)
+		name := it.campgroundID
+		var url string
+		if cg, ok, _ := b.store.GetCampgroundByID(ctx, it.provider, it.campgroundID); ok {
+			name = cg.Name
+		}
+		if pi, ok := b.registry.Get(it.provider); ok {
+			url = pi.CampgroundURL(it.campgroundID)
+		}
+
+		totalChecks, err := b.store.CountLookupsSinceTime(ctx, it.provider, it.campgroundID, it.created)
 		if err != nil {
 			b.logger.Warn("count request checks failed", "err", err)
 			totalChecks = 0
 		}
+		nights := int(it.checkout.Sub(it.checkin).Hours() / 24)
 
-		block := strings.Builder{}
-		block.WriteString(fmt.Sprintf("**%s** · `#%d`\n", name, it.id))
-		// Compact details line, separator-delimited so it wraps cleanly on mobile.
-		bits := []string{
-			fmt.Sprintf("%s %s → %s %s",
-				it.checkin.Format("2006-01-02"), weekday(it.checkin),
-				it.checkout.Format("2006-01-02"), weekday(it.checkout)),
-			fmt.Sprintf("%dn", nights),
-		}
+		bits := []string{}
 		if it.minimumNights.Valid {
 			bits = append(bits, fmt.Sprintf("min %d", it.minimumNights.Int64))
 		}
@@ -101,24 +95,30 @@ func (b *Bot) handleListCommand(s *discordgo.Session, i *discordgo.InteractionCr
 			bits = append(bits, it.strategy.String)
 		}
 		bits = append(bits, fmt.Sprintf("%d checks", totalChecks))
-		block.WriteString(strings.Join(bits, " · "))
-		block.WriteString("\n\n")
 
-		if desc.Len()+block.Len() > maxDesc {
-			flush()
-		}
-		desc.WriteString(block.String())
-	}
-	flush()
+		desc := fmt.Sprintf(
+			"**%s %s** → **%s %s**  ·  %d %s\n-# %s",
+			it.checkin.Format("2006-01-02"), it.checkin.Format("Mon"),
+			it.checkout.Format("2006-01-02"), it.checkout.Format("Mon"),
+			nights, nightsWord(nights),
+			strings.Join(bits, " · "),
+		)
 
-	for start := 0; start < len(embeds); start += 10 {
-		end := start + 10
-		if end > len(embeds) {
-			end = len(embeds)
-		}
-		_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{Embeds: embeds[start:end], Flags: 1 << 6})
-		if err != nil {
-			b.logger.Warn("state followup send failed", "err", err)
+		embeds = append(embeds, &discordgo.MessageEmbed{
+			Author:      &discordgo.MessageEmbedAuthor{Name: name, URL: url},
+			Description: desc,
+			Color:       colorFromName(parkOf(name)),
+		})
+		if len(embeds) == 10 {
+			flushBatch()
 		}
 	}
+	flushBatch()
+}
+
+func nightsWord(n int) string {
+	if n == 1 {
+		return "night"
+	}
+	return "nights"
 }

--- a/internal/bot/util.go
+++ b/internal/bot/util.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,61 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 )
+
+// colorFromName maps a name to a deterministic, bright-on-dark embed color.
+// Same input always produces the same color; useful for grouping items
+// (e.g. all campgrounds in one park share a color).
+func colorFromName(s string) int {
+	h := md5.Sum([]byte(s))
+	hue := float64(uint16(h[0])|uint16(h[1])<<8) / 65535.0
+	r, g, b := hslToRGB(hue, 0.55, 0.70)
+	return r<<16 | g<<8 | b
+}
+
+// hslToRGB converts HSL (all in [0,1]) to 0-255 RGB ints, matching Python's
+// colorsys.hls_to_rgb (note: Python's order is H, L, S).
+func hslToRGB(h, l, s float64) (int, int, int) {
+	if s == 0 {
+		v := int(l * 255)
+		return v, v, v
+	}
+	var m2 float64
+	if l <= 0.5 {
+		m2 = l * (1 + s)
+	} else {
+		m2 = l + s - l*s
+	}
+	m1 := 2*l - m2
+	c := func(x float64) int {
+		if x < 0 {
+			x += 1
+		}
+		if x > 1 {
+			x -= 1
+		}
+		switch {
+		case x*6 < 1:
+			return int((m1 + (m2-m1)*6*x) * 255)
+		case x*2 < 1:
+			return int(m2 * 255)
+		case x*3 < 2:
+			return int((m1 + (m2-m1)*(2.0/3.0-x)*6) * 255)
+		default:
+			return int(m1 * 255)
+		}
+	}
+	return c(h + 1.0/3.0), c(h), c(h - 1.0/3.0)
+}
+
+// parkOf returns the parent-park prefix of a campground name
+// ("Yosemite National Park: Upper Pines" -> "Yosemite National Park"),
+// falling back to the whole name when there is no ": " separator.
+func parkOf(name string) string {
+	if i := strings.Index(name, ":"); i >= 0 {
+		return strings.TrimSpace(name[:i])
+	}
+	return strings.TrimSpace(name)
+}
 
 func parseDates(s1, s2 string) (time.Time, time.Time, error) {
 	const layout = "2006-01-02"


### PR DESCRIPTION
## Summary
- `/schniff list` now renders one embed per schniff with the campground name as a clickable author header.
- Sidebar color is hashed from the parent-park portion of the campground name (before the first `:`), so every site in the same park shares a stable, deterministic color.
- `/schniff group list` renders one embed per group, author prefixed with `Group:`, sites bulleted with `▸`, color hashed from the group name.
- Nights spelled out (`4 nights`, `1 night`).

## Test plan
- [ ] `/schniff list` with multiple schniffs in the same national park — verify same sidebar color
- [ ] `/schniff list` with schniffs from different parks — verify distinct colors
- [ ] Campground name in author header links to the provider
- [ ] `/schniff group list` shows `Group: <name>` and hashed color per group
- [ ] Renders cleanly on Discord mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)