### PR TITLE
chore(booker): remove non-functional 2captcha fallback

### DIFF
--- a/cmd/booker/main.go
+++ b/cmd/booker/main.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	api2captcha "github.com/2captcha/2captcha-go"
 	"github.com/brensch/schniffer/internal/booker"
 )
 
@@ -34,7 +33,6 @@ func main() {
 		loginOnly  = flag.Bool("login-only", false, "stop after ensuring login")
 		timeout    = flag.Duration("timeout", 5*time.Minute, "overall timeout")
 		debugDir   = flag.String("debug-dir", "/work/.cache/debug", "directory for response dumps")
-		use2Cap    = flag.Bool("use-2captcha", false, "force the 2captcha API instead of in-page grecaptcha (needs 2CAPTCHA_API_KEY)")
 	)
 	flag.Parse()
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
@@ -84,40 +82,9 @@ func main() {
 	}
 	depart := arrival.AddDate(0, 0, *nights)
 	slog.Info("booking", "campsite", *campsite, "campground", *campground,
-		"arrival", arrival.Format("2006-01-02"), "depart", depart.Format("2006-01-02"),
-		"use_2captcha", *use2Cap)
+		"arrival", arrival.Format("2006-01-02"), "depart", depart.Format("2006-01-02"))
 
-	var (
-		res *booker.HoldResult
-	)
-	if *use2Cap {
-		// xvfb-run strips env vars with POSIX-invalid names (digits-first), so
-		// prefer TWOCAPTCHA_API_KEY but fall back to 2CAPTCHA_API_KEY.
-		apiKey := os.Getenv("TWOCAPTCHA_API_KEY")
-		if apiKey == "" {
-			apiKey = os.Getenv("2CAPTCHA_API_KEY")
-		}
-		if apiKey == "" {
-			fatal("TWOCAPTCHA_API_KEY (or 2CAPTCHA_API_KEY) not set")
-		}
-		pageURL := fmt.Sprintf("%s/camping/campsites/%s", booker.SiteOrigin, *campsite)
-		start := time.Now()
-		token, terr := solve2Captcha(apiKey, pageURL)
-		if terr != nil {
-			fatal("2captcha solve: %v", terr)
-		}
-		slog.Info("2captcha solved", "token_len", len(token), "took", time.Since(start))
-		res, err = sess.HoldCampsiteWithToken(ctx, *campsite, *campground, arrival, depart, token)
-	} else {
-		res, err = sess.HoldCampsite(ctx, *campsite, *campground, arrival, depart)
-	}
-	if err != nil {
-		if res != nil {
-			pretty, _ := json.MarshalIndent(res.Raw, "", "  ")
-			_ = os.WriteFile(filepath.Join(*debugDir, "last-response.json"), pretty, 0o644)
-		}
-		fatal("book: %v", err)
-	}
+	res, err := sess.HoldCampsite(ctx, *campsite, *campground, arrival, depart)
 	if err != nil {
 		if res != nil {
 			pretty, _ := json.MarshalIndent(res.Raw, "", "  ")
@@ -137,23 +104,4 @@ func main() {
 func fatal(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "fatal: "+strings.TrimRight(format, "\n")+"\n", args...)
 	os.Exit(1)
-}
-
-// solve2Captcha mints a reCAPTCHA Enterprise v3 token for the rec.gov
-// booking action. 2captcha typically takes 15-60s. Returns the token string
-// ready to splice into the gate_a.value field.
-func solve2Captcha(apiKey, pageURL string) (string, error) {
-	client := api2captcha.NewClient(apiKey)
-	client.DefaultTimeout = 180
-	client.PollingInterval = 5
-	cap := api2captcha.ReCaptcha{
-		SiteKey:    booker.RecaptchaSiteKey,
-		Url:        pageURL,
-		Version:    "v3",
-		Action:     booker.RecaptchaAction,
-		Enterprise: true,
-		Score:      0.3,
-	}
-	token, _, err := client.Solve(cap.ToRequest())
-	return token, err
 }

--- a/docs/booker-reproduction.md
+++ b/docs/booker-reproduction.md
@@ -1,7 +1,9 @@
 # Booker prototype — how the working flow runs today
 
-Snapshot of the current end-to-end flow, taken after the 2026-06-07 round of
-testing. Two successful holds were placed during that session:
+Snapshot of the current end-to-end flow, taken after the 2026-06-08
+cleanup that removed the (non-functional) 2captcha fallback path. The
+earlier 2026-06-07 testing round placed two successful holds via the
+in-page reCAPTCHA Enterprise path:
 
 - Campsite **10085607** (Baker Dam), 2026-10-15 → 2026-10-16. Order
   `13c48a05-cb69-4642-9254-f025fcdc35e6`. Took ~1.5s booking time.
@@ -46,7 +48,7 @@ container that had a different hostname), `booker.Open` deletes
 ### 3. Booker library — `internal/booker`
 
 - `Session` (booker.go): owns one Chrome instance via chromedp; exposes
-  `Login`, `HoldCampsite`, `HoldCampsiteWithToken`, `Refresh`, `Close`.
+  `Login`, `HoldCampsite`, `Refresh`, `Close`.
 - `Pool` (pool.go): per-user warm sessions for the production bot path.
 - `selection.go`: pure selection algorithm (longest contiguous stretch,
   tie-break by rating).
@@ -64,7 +66,6 @@ Flags worth knowing:
 | `-nights`        | `1`                              | Length of stay.                                         |
 | `-profile`       | `$CHROME_PROFILE`                | Chrome user-data-dir.                                   |
 | `-login-only`    | `false`                          | Just warm cookies + JWT, don't book.                    |
-| `-use-2captcha`  | `false`                          | Force the 2captcha fallback path (see "What 2captcha did" below). |
 | `-debug-dir`     | `/work/.cache/debug`             | Last response JSON + (on failure) screenshot/html.      |
 | `-timeout`       | `5m`                             | Overall context timeout.                                |
 
@@ -83,13 +84,7 @@ Flags worth knowing:
 ```
 REC_GOV_EMAIL=you@example.com
 REC_GOV_PASSWORD=...
-2CAPTCHA_API_KEY=...               # only needed for -use-2captcha
 ```
-
-`scripts/booker-run.sh` aliases `2CAPTCHA_API_KEY` → `TWOCAPTCHA_API_KEY`
-inside the container because `xvfb-run` strips env vars with POSIX-invalid
-names (any var starting with a digit). The Go code reads
-`TWOCAPTCHA_API_KEY` first, falls back to `2CAPTCHA_API_KEY`.
 
 ## Step-by-step: what one successful booking actually does
 
@@ -219,7 +214,7 @@ What happens, in order:
 
 ```
 time=… level=INFO msg="logging in"
-time=… level=INFO msg=booking campsite=89223 campground=233907 arrival=2026-07-07 depart=2026-07-08 use_2captcha=false
+time=… level=INFO msg=booking campsite=89223 campground=233907 arrival=2026-07-07 depart=2026-07-08
 
 Reservation held: https://www.recreation.gov/camping/reservations/orderdetails?id=21f8a377-c371-4202-b5b1-b6b668969fb0
 ```
@@ -257,9 +252,9 @@ every run, success or failure.
 - **`fatal: book: human verification required: Our system has detected
   abnormal activity from your computer network`** — risk score dropped.
   Causes seen: VPN/datacenter IP, fresh profile dir with no
-  `r1s-fingerprint` history, using `--headless`, using a 2captcha-minted
-  token (see below). Cures: slow down, run from residential IP, warm a
-  profile with manual browsing first, never use `--headless`.
+  `r1s-fingerprint` history, using `--headless`. Cures: slow down, run
+  from residential IP, warm a profile with manual browsing first, never
+  use `--headless`.
 - **`fatal: login: bad credentials`** — wrong password, MFA enabled on
   account, or rec.gov is rejecting the login challenge. The form-fill
   path doesn't yet handle the latter two; you'd need to log in manually
@@ -278,36 +273,28 @@ every run, success or failure.
   helper has not been ported into the library. If you need it, copy
   `dumpDebug` from the git history of `cmd/booker/main.go` pre-refactor.
 
-## What the 2captcha test showed (2026-06-07)
+## Why 2captcha was ripped out (2026-06-08)
 
-We added a `-use-2captcha` flag and ran the same booking flow but had
-2captcha mint the reCAPTCHA Enterprise v3 token instead of letting the
-page do it. Result:
-
-| Path                                       | Outcome                                                                 | Time            |
-| ------------------------------------------ | ----------------------------------------------------------------------- | --------------- |
-| In-page `grecaptcha.enterprise.execute()`  | ✅ Held                                                                  | ~1.5s           |
-| 2captcha-minted token spliced into `gate_a`| ❌ "abnormal activity" (mapped to `ErrHumanVerification`)                | ~16s + rejection|
-
-reCAPTCHA Enterprise v3 tokens are silently bound to the issuing browser's
-fingerprint (IP, UA, cookie state). 2captcha mints from their farm; when
-our session POSTs that token, Google's risk engine sees the mismatch and
-returns a near-zero score, which rec.gov surfaces as the abnormal-activity
-rejection. The flag is left in place as a kill-switch but should be
-considered non-functional until we find a captcha provider that supports
-Enterprise v3 with proper fingerprint binding.
+We previously had a `-use-2captcha` flag that minted the reCAPTCHA
+Enterprise v3 token via the 2captcha API and spliced it into `gate_a`.
+The 2026-06-07 test showed it doesn't work: reCAPTCHA Enterprise v3 tokens
+are silently bound to the issuing browser's fingerprint (IP, UA, cookie
+state). 2captcha mints from their farm; when our session POSTs that
+token, Google's risk engine sees the mismatch, returns a near-zero score,
+and rec.gov surfaces it as `ErrHumanVerification` ("abnormal activity").
+Only the in-page `grecaptcha.enterprise.execute()` path holds. The flag,
+solver, and `HoldCampsiteWithToken` entry point have been removed.
 
 ## Files that matter
 
 | Path                                | Role                                                              |
 | ----------------------------------- | ----------------------------------------------------------------- |
 | `docker/Dockerfile.booker`          | Container image: golang:1.26-bookworm + Chrome + Xvfb + tini.     |
-| `scripts/booker-run.sh`             | Build-and-run wrapper. Handles `2CAPTCHA_API_KEY` aliasing.       |
+| `scripts/booker-run.sh`             | Build-and-run wrapper.                                            |
 | `scripts/booker-shell.sh`           | Interactive shell in the dev container.                           |
 | `cmd/booker/main.go`                | CLI; parses flags, calls the library.                             |
-| `internal/booker/booker.go`         | `Session`: launch Chrome, `Login`, `HoldCampsite[WithToken]`.     |
+| `internal/booker/booker.go`         | `Session`: launch Chrome, `Login`, `HoldCampsite`.                |
 | `internal/booker/pool.go`           | Per-user warm pool (for production bot integration).              |
 | `internal/booker/selection.go`      | Pure selection algorithm + tests.                                 |
-| `internal/booker/captcha.go`        | (planned — 2captcha solver wrapper; currently inline in `cmd/booker/main.go`.) |
 | `.cache/recgov-profile/`            | Persistent Chrome user-data-dir.                                  |
 | `.cache/debug/last-response.json`   | Most recent rec.gov response body.                                |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.26
 
 require (
 	github.com/bwmarrin/discordgo v0.27.1
+	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc
+	github.com/chromedp/chromedp v0.15.1
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/robfig/cron/v3 v3.0.1
@@ -12,9 +14,6 @@ require (
 )
 
 require (
-	github.com/2captcha/2captcha-go v1.1.10 // indirect
-	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc // indirect
-	github.com/chromedp/chromedp v0.15.1 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/2captcha/2captcha-go v1.1.10 h1:U3Y7VLwR9z5XpCMijB+FkhHRt6QikKnHDEy1uLQVCD8=
-github.com/2captcha/2captcha-go v1.1.10/go.mod h1:TsupeToBP0BPHfZOQpNDb61NKqtbBJ2ddptqSK2p9/M=
 github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=
 github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc h1:wkN/LMi5vc60pBRWx6qpbk/aEvq3/ZVNpnMvsw8PVVU=
@@ -22,8 +20,12 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
+github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
+github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
@@ -37,8 +39,6 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -216,19 +216,6 @@ type HoldResult struct {
 // HoldCampsite navigates to the campsite page, mints a fresh reCAPTCHA
 // Enterprise token in-page, and POSTs to the multi-reservation endpoint.
 func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
-	return s.holdCampsiteWithToken(ctx, campsiteID, campgroundID, checkIn, checkOut, "")
-}
-
-// HoldCampsiteWithToken does the same but uses presetToken (e.g. from
-// 2captcha) instead of calling grecaptcha.enterprise.execute() in-page.
-func (s *Session) HoldCampsiteWithToken(ctx context.Context, campsiteID, campgroundID string, checkIn, checkOut time.Time, presetToken string) (*HoldResult, error) {
-	if presetToken == "" {
-		return nil, errors.New("presetToken required")
-	}
-	return s.holdCampsiteWithToken(ctx, campsiteID, campgroundID, checkIn, checkOut, presetToken)
-}
-
-func (s *Session) holdCampsiteWithToken(ctx context.Context, campsiteID, campgroundID string, checkIn, checkOut time.Time, presetToken string) (*HoldResult, error) {
 	const iso = "2006-01-02T00:00:00.000Z"
 	if !checkIn.Before(checkOut) {
 		return nil, errors.New("check-in must be before check-out")
@@ -239,13 +226,11 @@ func (s *Session) holdCampsiteWithToken(ctx context.Context, campsiteID, campgro
 	); err != nil {
 		return nil, fmt.Errorf("nav: %w", err)
 	}
-	if presetToken == "" {
-		if err := chromedp.Run(ctx, chromedp.Poll(
-			`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
-			nil, chromedp.WithPollingTimeout(30*time.Second),
-		)); err != nil {
-			return nil, fmt.Errorf("wait recaptcha: %w", err)
-		}
+	if err := chromedp.Run(ctx, chromedp.Poll(
+		`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
+		nil, chromedp.WithPollingTimeout(30*time.Second),
+	)); err != nil {
+		return nil, fmt.Errorf("wait recaptcha: %w", err)
 	}
 	nightMap := map[string]map[string]string{}
 	for day := checkIn; day.Before(checkOut); day = day.AddDate(0, 0, 1) {
@@ -263,13 +248,10 @@ func (s *Session) holdCampsiteWithToken(ctx context.Context, campsiteID, campgro
 		"nightMap":     nightMap,
 		"siteKey":      RecaptchaSiteKey,
 		"action":       RecaptchaAction,
-		"presetToken":  presetToken,
 	}
 	payloadJSON, _ := json.Marshal(payload)
 	script := `(async (p) => {
-		const token = p.presetToken && p.presetToken.length > 0
-			? p.presetToken
-			: await grecaptcha.enterprise.execute(p.siteKey, {action: p.action});
+		const token = await grecaptcha.enterprise.execute(p.siteKey, {action: p.action});
 		const recRaw = window.localStorage.getItem('recaccount');
 		if (!recRaw) throw new Error('no recaccount in localStorage');
 		const rec = JSON.parse(recRaw);

--- a/scripts/booker-run.sh
+++ b/scripts/booker-run.sh
@@ -26,4 +26,4 @@ docker run --rm \
     -e XDG_CONFIG_HOME=/work/.cache/.config \
     --env-file .env \
     "$IMAGE" \
-    bash -c 'if [ -z "${TWOCAPTCHA_API_KEY:-}" ]; then export TWOCAPTCHA_API_KEY="$(printenv 2CAPTCHA_API_KEY 2>/dev/null || true)"; fi; xvfb-run -a -s "-screen 0 1280x900x24" go run ./cmd/booker '"$*"
+    bash -c 'xvfb-run -a -s "-screen 0 1280x900x24" go run ./cmd/booker '"$*"


### PR DESCRIPTION
The 2captcha-minted reCAPTCHA Enterprise v3 token path never worked in practice — Google binds v3 tokens to the issuing browser fingerprint, so rec.gov rejected 2captcha-minted tokens as abnormal activity. Only the in-page grecaptcha.enterprise.execute() path was ever used in production. Rip out the -use-2captcha flag, solver, HoldCampsiteWithToken entry point, the 2captcha-go dependency, and the env-var aliasing shim.