### PR TITLE
fix(booker): surface lost-race 400s as bot-on-bot, log response body

### DIFF
--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -39,6 +39,11 @@ var ErrBadCredentials = errors.New("bad credentials")
 // reCAPTCHA score and requires its visible human-verification challenge.
 var ErrHumanVerification = errors.New("human verification required")
 
+// ErrSiteUnavailable is returned when rec.gov rejects the booking with a 400.
+// In practice this means the site was taken between our availability poll and
+// our POST — someone else (often another bot) got there first.
+var ErrSiteUnavailable = errors.New("site no longer available")
+
 type Config struct {
 	ProfileDir string
 	ChromePath string // empty = autodetect
@@ -305,7 +310,12 @@ func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID str
 func bookingResponseError(response map[string]any, orderID string) error {
 	status, _ := response["status"].(float64)
 	if status < 200 || status >= 300 {
-		return fmt.Errorf("rec.gov returned status %v", response["status"])
+		body, _ := json.Marshal(response)
+		slog.Warn("rec.gov booking rejected", slog.Any("status", response["status"]), slog.String("body", string(body)))
+		if int(status) == 400 {
+			return fmt.Errorf("%w (rec.gov 400)", ErrSiteUnavailable)
+		}
+		return fmt.Errorf("rec.gov returned status %v: %s", response["status"], string(body))
 	}
 	message, _ := response["error"].(string)
 	if ok, exists := response["ok"].(bool); exists && !ok {

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -330,6 +330,9 @@ func formatBookingOutcome(pick booker.Pick, res *booker.HoldResult, err error) s
 			return fmt.Sprintf("⚠️ Recreation.gov requires a human verification step for site **%s**. [Open the site and finish manually](%s).",
 				pick.CampsiteID, url)
 		}
+		if errors.Is(err, booker.ErrSiteUnavailable) {
+			return fmt.Sprintf("🤖 Bot-on-bot violence: someone else grabbed site **%s** before us.", pick.CampsiteID)
+		}
 		return fmt.Sprintf("❌ Couldn't hold site **%s**: %s", pick.CampsiteID, err.Error())
 	}
 	url := ""


### PR DESCRIPTION
## Summary
- New `booker.ErrSiteUnavailable` sentinel; any non-2xx rec.gov booking response now logs the full body at WARN for future diagnosis.
- 400s map to that sentinel and render on Discord as `🤖 Bot-on-bot violence: someone else grabbed site **X** before us.` instead of the cryptic `rec.gov returned status 400`.

## Context
Triggered by a real lost race on site 179 (campground 232447) at 07:50 today: the bot detected availability, POSTed ~4s later, got a 400, and on the next poll the site had already flipped back to unavailable — classic someone-else-booked-first. The previous response body was never captured, so we couldn't confirm. Now we will.

## Test plan
- [ ] Trigger a hold against a known-unavailable site and confirm the Discord message reads "Bot-on-bot violence".
- [ ] Confirm a non-400 failure still surfaces the status code + body in the error string.
- [ ] Verify the WARN `rec.gov booking rejected` log line appears with the JSON body for any non-2xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)