### PR TITLE
Arbitrate users per campground + handle basket expiry

### DIFF
--- a/internal/db/booking.go
+++ b/internal/db/booking.go
@@ -115,6 +115,52 @@ func (s *Store) InsertBooking(ctx context.Context, b Booking) (int64, error) {
 	return res.LastInsertId()
 }
 
+// RecentHoldOwner describes the user whose held booking on a given campsite
+// is the most recent within the lookup window. Used to detect cart-hold
+// expiries: when a campsite flips back to available shortly after we held
+// it, the original holder gets a "basket expired" follow-up DM instead of
+// another auto-book attempt for them.
+type RecentHoldOwner struct {
+	CampsiteID  string
+	UserID      string
+	Checkin     time.Time
+	Checkout    time.Time
+	AttemptedAt time.Time
+}
+
+// RecentHoldOwnersForCampground returns the most recent held booking per
+// campsite within the given campground that was attempted after `since`.
+// One row per campsite (latest wins on ties). Callers intersect the held
+// window with the dates that just became available.
+func (s *Store) RecentHoldOwnersForCampground(ctx context.Context, provider, campgroundID string, since time.Time) ([]RecentHoldOwner, error) {
+	rows, err := s.ReadConnection().QueryContext(ctx, `
+		SELECT campsite_id, user_id, checkin, checkout, attempted_at
+		FROM bookings
+		WHERE provider=? AND campground_id=?
+		  AND outcome='held'
+		  AND attempted_at > ?
+		ORDER BY campsite_id, attempted_at DESC
+	`, provider, campgroundID, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RecentHoldOwner
+	seen := map[string]bool{}
+	for rows.Next() {
+		var r RecentHoldOwner
+		if err := rows.Scan(&r.CampsiteID, &r.UserID, &r.Checkin, &r.Checkout, &r.AttemptedAt); err != nil {
+			return nil, err
+		}
+		if seen[r.CampsiteID] {
+			continue
+		}
+		seen[r.CampsiteID] = true
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) ListBookingsByBatch(ctx context.Context, batchID string) ([]Booking, error) {
 	rows, err := s.ReadConnection().QueryContext(ctx, `
 		SELECT id, batch_id, user_id, provider, campground_id, campsite_id, checkin, checkout, outcome, order_id, error_msg, attempted_at

--- a/internal/manager/arbitration.go
+++ b/internal/manager/arbitration.go
@@ -1,0 +1,159 @@
+package manager
+
+import (
+	"sort"
+
+	"github.com/brensch/schniffer/internal/booker"
+	"github.com/brensch/schniffer/internal/db"
+)
+
+// ArbInput is the per-request input to arbitration: a schniff request and
+// its already-filtered candidate pool (newly-available campsites with the
+// dates that fall in the user's window, after minimum_nights / strategy
+// gating).
+type ArbInput struct {
+	Request    db.SchniffRequest
+	Candidates []booker.Candidate
+}
+
+// DisplacementRecord describes one site that this request had eligible but
+// lost to an older (lower request_id) competitor.
+type DisplacementRecord struct {
+	CampsiteID   string
+	WinnerUserID string
+	WinnerReqID  int64
+	WinnerNights int
+}
+
+// ArbResult is the per-request output of arbitration.
+type ArbResult struct {
+	Request db.SchniffRequest
+	// Won: this request was assigned a campsite via arbitration. Auto-book
+	// attempts go out for these.
+	Won  bool
+	Pick booker.Pick
+
+	// ExpiringOwner: this request's user is the most-recent holder of a
+	// campsite in their candidate pool, within the recent-hold window. They
+	// are excluded from auto-booking that site (would be an infinite loop)
+	// and get a special "basket expired" follow-up DM instead. If the same
+	// user could have won other sites via arbitration, Won + Pick still
+	// reflect that.
+	ExpiringOwner       bool
+	ExpiringOwnerPick   booker.Pick // the site they had held, for the follow-up DM
+	ExpiringOwnerHadCap bool        // there was at least one date overlap
+
+	// DisplacedBy: campsites this request's user could have used but lost to
+	// other users. Populated only when Won == false and at least one of the
+	// candidates was awarded to a different user. Used for the "older
+	// schniff won" summary DM, sent after winner holds succeed.
+	DisplacedBy []DisplacementRecord
+}
+
+// Arbitrate runs greedy global assignment over (request, campsite) pairs.
+// At each step the highest-scoring still-eligible pair wins: more nights →
+// higher rating → lower request_id. Once a campsite is taken or a request
+// already has a win, both drop out of the pool.
+//
+// A pair where the request's user is the expiringOwners[campsite] (their
+// own hold just expired on that site) is excluded — we never auto-book the
+// same user the same site they just let go.
+func Arbitrate(inputs []ArbInput, expiringOwners map[string]string) []ArbResult {
+	type pairScore struct {
+		reqIdx int
+		pick   booker.Pick
+	}
+	var pairs []pairScore
+	for i, in := range inputs {
+		for _, c := range in.Candidates {
+			if owner, ok := expiringOwners[c.CampsiteID]; ok && owner == in.Request.UserID {
+				continue
+			}
+			pick, ok := booker.SelectBestPartial([]booker.Candidate{c})
+			if !ok {
+				continue
+			}
+			pairs = append(pairs, pairScore{reqIdx: i, pick: pick})
+		}
+	}
+
+	sort.SliceStable(pairs, func(i, j int) bool {
+		if pairs[i].pick.Nights != pairs[j].pick.Nights {
+			return pairs[i].pick.Nights > pairs[j].pick.Nights
+		}
+		if pairs[i].pick.Rating != pairs[j].pick.Rating {
+			return pairs[i].pick.Rating > pairs[j].pick.Rating
+		}
+		return inputs[pairs[i].reqIdx].Request.ID < inputs[pairs[j].reqIdx].Request.ID
+	})
+
+	wonByReq := map[int]booker.Pick{}
+	wonBySite := map[string]int{}
+	for _, p := range pairs {
+		if _, taken := wonBySite[p.pick.CampsiteID]; taken {
+			continue
+		}
+		if _, alreadyWon := wonByReq[p.reqIdx]; alreadyWon {
+			continue
+		}
+		wonByReq[p.reqIdx] = p.pick
+		wonBySite[p.pick.CampsiteID] = p.reqIdx
+	}
+
+	results := make([]ArbResult, len(inputs))
+	for i, in := range inputs {
+		r := ArbResult{Request: in.Request}
+		if pick, ok := wonByReq[i]; ok {
+			r.Won = true
+			r.Pick = pick
+		}
+
+		// ExpiringOwner: did this user have one of their own recently-held
+		// sites in their candidate pool?
+		for _, c := range in.Candidates {
+			if owner, ok := expiringOwners[c.CampsiteID]; ok && owner == in.Request.UserID {
+				pick, hasDates := booker.SelectBestPartial([]booker.Candidate{c})
+				r.ExpiringOwner = true
+				r.ExpiringOwnerHadCap = hasDates
+				if hasDates {
+					r.ExpiringOwnerPick = pick
+				} else {
+					r.ExpiringOwnerPick = booker.Pick{CampsiteID: c.CampsiteID}
+				}
+				break
+			}
+		}
+
+		// Displacement (strict): only report displacements for requests that
+		// walked away empty-handed (no Won). A request that won a different
+		// site doesn't get spammed about sites it didn't get.
+		if !r.Won {
+			for _, c := range in.Candidates {
+				winnerIdx, taken := wonBySite[c.CampsiteID]
+				if !taken {
+					continue
+				}
+				if winnerIdx == i {
+					continue
+				}
+				winnerReq := inputs[winnerIdx].Request
+				if winnerReq.ID == in.Request.ID {
+					continue
+				}
+				nights := 0
+				if w, ok := wonByReq[winnerIdx]; ok && w.CampsiteID == c.CampsiteID {
+					nights = w.Nights
+				}
+				r.DisplacedBy = append(r.DisplacedBy, DisplacementRecord{
+					CampsiteID:   c.CampsiteID,
+					WinnerUserID: winnerReq.UserID,
+					WinnerReqID:  winnerReq.ID,
+					WinnerNights: nights,
+				})
+			}
+		}
+
+		results[i] = r
+	}
+	return results
+}

--- a/internal/manager/arbitration_test.go
+++ b/internal/manager/arbitration_test.go
@@ -1,0 +1,147 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brensch/schniffer/internal/booker"
+	"github.com/brensch/schniffer/internal/db"
+)
+
+func arbDay(d int) time.Time {
+	return time.Date(2026, 7, d, 0, 0, 0, 0, time.UTC)
+}
+
+func mkReq(id int64, userID string) db.SchniffRequest {
+	return db.SchniffRequest{
+		ID:        id,
+		UserID:    userID,
+		Provider:  "recreation_gov",
+		Checkin:   arbDay(1),
+		Checkout:  arbDay(10),
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestArbitrate_OldestWinsSingleSite(t *testing.T) {
+	a := mkReq(1, "alice")
+	b := mkReq(2, "bob")
+	cand := []booker.Candidate{{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}}}
+	res := Arbitrate([]ArbInput{{a, cand}, {b, cand}}, nil)
+	if !res[0].Won {
+		t.Fatal("alice should win — lower request_id")
+	}
+	if res[1].Won {
+		t.Fatal("bob should not win")
+	}
+	if len(res[1].DisplacedBy) != 1 || res[1].DisplacedBy[0].WinnerUserID != "alice" {
+		t.Fatalf("bob should be displaced by alice, got %+v", res[1].DisplacedBy)
+	}
+}
+
+func TestArbitrate_LongerBookingWinsEvenIfNewer(t *testing.T) {
+	a := mkReq(1, "alice")
+	b := mkReq(2, "bob")
+	// Same site X. Alice's pool gives 1 night, Bob's gives 5 nights.
+	res := Arbitrate([]ArbInput{
+		{a, []booker.Candidate{{CampsiteID: "X", Dates: []time.Time{arbDay(1)}}}},
+		{b, []booker.Candidate{{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2), arbDay(3), arbDay(4), arbDay(5)}}}},
+	}, nil)
+	if !res[1].Won {
+		t.Fatal("bob should win — longer booking trumps request_id")
+	}
+	if res[0].Won {
+		t.Fatal("alice should not win")
+	}
+	if len(res[0].DisplacedBy) != 1 || res[0].DisplacedBy[0].WinnerUserID != "bob" {
+		t.Fatalf("alice should be displaced by bob")
+	}
+}
+
+func TestArbitrate_DistributeOneEach(t *testing.T) {
+	a := mkReq(1, "alice")
+	b := mkReq(2, "bob")
+	candAB := []booker.Candidate{
+		{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}},
+		{CampsiteID: "Y", Dates: []time.Time{arbDay(1), arbDay(2)}},
+	}
+	res := Arbitrate([]ArbInput{{a, candAB}, {b, candAB}}, nil)
+	if !res[0].Won || !res[1].Won {
+		t.Fatalf("both should win different sites, got %+v", res)
+	}
+	if res[0].Pick.CampsiteID == res[1].Pick.CampsiteID {
+		t.Fatalf("alice and bob got same site %s", res[0].Pick.CampsiteID)
+	}
+	if len(res[0].DisplacedBy) != 0 || len(res[1].DisplacedBy) != 0 {
+		t.Fatalf("nobody should be displaced when each got a site")
+	}
+}
+
+func TestArbitrate_ExpiringOwnerExcluded(t *testing.T) {
+	a := mkReq(1, "alice")
+	b := mkReq(2, "bob")
+	cand := []booker.Candidate{{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}}}
+	// Alice's hold on X just expired — she can't auto-book it again.
+	res := Arbitrate([]ArbInput{{a, cand}, {b, cand}}, map[string]string{"X": "alice"})
+	if res[0].Won {
+		t.Fatal("alice should not win — expiring owner excluded")
+	}
+	if !res[0].ExpiringOwner {
+		t.Fatal("alice should be classified as expiring owner")
+	}
+	if !res[1].Won {
+		t.Fatal("bob should win since alice is excluded")
+	}
+}
+
+func TestArbitrate_ExpiringOwnerStillWinsDifferentSite(t *testing.T) {
+	a := mkReq(1, "alice")
+	cand := []booker.Candidate{
+		{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}}, // alice held this
+		{CampsiteID: "Y", Dates: []time.Time{arbDay(1), arbDay(2)}}, // alice can have this
+	}
+	res := Arbitrate([]ArbInput{{a, cand}}, map[string]string{"X": "alice"})
+	if !res[0].Won {
+		t.Fatal("alice should win site Y")
+	}
+	if res[0].Pick.CampsiteID != "Y" {
+		t.Fatalf("alice should win Y not %s", res[0].Pick.CampsiteID)
+	}
+	if !res[0].ExpiringOwner {
+		t.Fatal("alice still flagged as expiring owner (gets the basket-expired DM for X)")
+	}
+}
+
+func TestArbitrate_StrictDisplacementOnlyForLosers(t *testing.T) {
+	a := mkReq(1, "alice")
+	b := mkReq(2, "bob")
+	// 2 sites, alice wins X; bob loses X but wins Y. Bob should NOT see X
+	// in his displacement list (he won something else).
+	candA := []booker.Candidate{
+		{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2), arbDay(3), arbDay(4)}},
+	}
+	candB := []booker.Candidate{
+		{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}},
+		{CampsiteID: "Y", Dates: []time.Time{arbDay(1), arbDay(2)}},
+	}
+	res := Arbitrate([]ArbInput{{a, candA}, {b, candB}}, nil)
+	if !res[0].Won || res[0].Pick.CampsiteID != "X" {
+		t.Fatalf("alice should win X with 4 nights, got %+v", res[0])
+	}
+	if !res[1].Won || res[1].Pick.CampsiteID != "Y" {
+		t.Fatalf("bob should win Y (X taken), got %+v", res[1])
+	}
+	if len(res[1].DisplacedBy) != 0 {
+		t.Fatalf("bob already won Y so should not be DM'd about losing X")
+	}
+}
+
+func TestArbitrate_TieBrokenByRequestID(t *testing.T) {
+	a := mkReq(5, "alice")
+	b := mkReq(3, "bob") // bob has lower id despite later in slice
+	cand := []booker.Candidate{{CampsiteID: "X", Dates: []time.Time{arbDay(1), arbDay(2)}}}
+	res := Arbitrate([]ArbInput{{a, cand}, {b, cand}}, nil)
+	if !res[1].Won {
+		t.Fatal("bob should win on lower request_id tiebreak")
+	}
+}

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -20,12 +20,18 @@ import (
 
 // ------- Public API on Manager -------
 
-// ProcessNotificationsWithBatches handles the state-change-based notification system.
-// DB access, logging, and notifier usage live here (methods on Manager).
+// recentHoldWindow is how far back we look in the bookings table to decide
+// whether a campsite flipping back to "available" is one of our own holds
+// expiring (vs. a genuine new opening). rec.gov cart holds last 15 minutes;
+// the extra few cover polling jitter.
+const recentHoldWindow = 20 * time.Minute
+
+// ProcessNotificationsWithBatches handles the state-change-based notification
+// system. Requests are grouped into (provider, campground) buckets so we can
+// arbitrate between users who want the same site before any holds fire.
 func (m *Manager) ProcessNotificationsWithBatches(ctx context.Context, requests []db.SchniffRequest) error {
 	m.logger.Info("processing notifications", slog.Int("request_count", len(requests)))
 
-	// Get unnotified state changes for all requests
 	stateChanges, err := m.store.GetUnnotifiedStateChanges(ctx, requests)
 	if err != nil {
 		m.logger.Warn("get unnotified state changes failed", slog.Any("err", err))
@@ -36,79 +42,43 @@ func (m *Manager) ProcessNotificationsWithBatches(ctx context.Context, requests 
 		return nil
 	}
 
-	// Group changes per request (pure helper)
 	changesByRequest := groupStateChangesByRequest(stateChanges)
-	m.logger.Info("grouped state changes by request", slog.Int("requests", len(changesByRequest)))
-
-	// Batch ID for recording notifications
-	batchID := uuid.New().String()
-	var notificationsToRecord []db.Notification
-	now := time.Now()
-
-	// Process each request independently. DM sends are I/O-bound and slow
-	// (~100-300ms each), so fan out with a bounded worker pool.
 	reqIndex := indexRequestsByID(requests)
-	const maxConcurrentDMs = 5
-	sem := make(chan struct{}, maxConcurrentDMs)
-	var nwg sync.WaitGroup
-	var nmu sync.Mutex
 
-	for requestID, changes := range changesByRequest {
-		req, ok := reqIndex[requestID]
+	type bucketKey struct{ provider, campground string }
+	bucketReqs := map[bucketKey][]int64{}
+	for reqID := range changesByRequest {
+		r, ok := reqIndex[reqID]
 		if !ok {
-			m.logger.Warn("request not found for state changes", slog.Int64("requestID", requestID))
+			m.logger.Warn("request not found for state changes", slog.Int64("requestID", reqID))
 			continue
 		}
+		k := bucketKey{r.Provider, r.CampgroundID}
+		bucketReqs[k] = append(bucketReqs[k], reqID)
+	}
 
-		m.logger.Info("processing request",
-			slog.Int64("requestID", requestID),
-			slog.String("provider", req.Provider),
-			slog.String("campgroundID", req.CampgroundID),
-			slog.Int("changes", len(changes)),
-		)
+	batchID := uuid.New().String()
+	now := time.Now()
 
-		nwg.Add(1)
-		sem <- struct{}{}
-		go func(req db.SchniffRequest, changes []db.StateChangeForRequest) {
-			defer nwg.Done()
-			defer func() { <-sem }()
+	var nmu sync.Mutex
+	var notificationsToRecord []db.Notification
 
-			sent, sendErr := m.sendStateChangeNotification(ctx, req, changes, batchID)
-			if sendErr != nil {
-				m.logger.Warn("send state change notification failed",
-					slog.String("userID", req.UserID),
-					slog.Any("err", sendErr))
-			}
-			if sent {
-				_, _ = m.notifier.ChannelMessageSend(m.summaryChannelID, nonsense.RandomSillyBroadcast(req.UserID))
-			}
-
-			local := make([]db.Notification, 0, len(changes))
-			for _, c := range changes {
-				state := "available"
-				if !c.NewAvailable {
-					state = "unavailable"
-				}
-				local = append(local, db.Notification{
-					RequestID:     req.ID,
-					UserID:        req.UserID,
-					Provider:      c.Provider,
-					CampgroundID:  c.CampgroundID,
-					CampsiteID:    c.CampsiteID,
-					Date:          c.Date,
-					State:         state,
-					StateChangeID: &c.ID,
-					SentAt:        now,
-				})
+	var bwg sync.WaitGroup
+	for k, ids := range bucketReqs {
+		bwg.Add(1)
+		go func(k bucketKey, ids []int64) {
+			defer bwg.Done()
+			notes := m.processCampgroundBucket(ctx, k.provider, k.campground, ids, reqIndex, changesByRequest, batchID, now)
+			if len(notes) == 0 {
+				return
 			}
 			nmu.Lock()
-			notificationsToRecord = append(notificationsToRecord, local...)
+			notificationsToRecord = append(notificationsToRecord, notes...)
 			nmu.Unlock()
-		}(req, changes)
+		}(k, ids)
 	}
-	nwg.Wait()
+	bwg.Wait()
 
-	// Record all notifications (single DB call)
 	if len(notificationsToRecord) > 0 {
 		if err := m.store.InsertNotificationsBatch(ctx, notificationsToRecord, batchID); err != nil {
 			m.logger.Warn("record notification batch failed", slog.Any("err", err))
@@ -122,205 +92,393 @@ func (m *Manager) ProcessNotificationsWithBatches(ctx context.Context, requests 
 	return nil
 }
 
-// sendStateChangeNotification fetches context data, builds the embed(s) via pure helpers, and sends them.
-// It returns 'sent = true' iff a DM was sent (i.e., there was at least one newly-available change).
-func (m *Manager) sendStateChangeNotification(
+// preparedRequest carries the per-request data we need across arbitration
+// and dispatch within a single bucket goroutine.
+type preparedRequest struct {
+	req          db.SchniffRequest
+	changes      []db.StateChangeForRequest
+	allAvailable []db.AvailabilityItem
+	candidates   []booker.Candidate
+}
+
+// bookOutcome travels back from the per-winner hold goroutines to the
+// bucket coordinator, which uses .success to decide which displaced losers
+// get DM'd.
+type bookOutcome struct {
+	winnerReqID  int64
+	winnerUserID string
+	pick         booker.Pick
+	success      bool
+}
+
+// processCampgroundBucket arbitrates between all requests pointing at the
+// same campground, dispatches the resulting DMs / channel pings / holds,
+// then (after holds finish) sends "older schniff won" summary DMs to losers.
+// Returns the notification rows to insert for the whole bucket.
+func (m *Manager) processCampgroundBucket(
 	ctx context.Context,
-	req db.SchniffRequest,
-	changes []db.StateChangeForRequest,
+	provider, campgroundID string,
+	reqIDs []int64,
+	reqIndex map[int64]db.SchniffRequest,
+	changesByRequest map[int64][]db.StateChangeForRequest,
 	batchID string,
-) (sent bool, err error) {
-	// Decide based on the provided changes (avoid any redundant lookups).
-	newlyAvail, _ := separateChanges(changes)
-	if len(newlyAvail) == 0 {
-		m.logger.Info("no newly-available changes; skipping DM",
-			slog.Int64("requestID", req.ID),
-			slog.String("userID", req.UserID),
-			slog.String("campgroundID", req.CampgroundID))
-		return false, nil
-	}
-
-	// Build the current availability context for the requested date range.
-	// We need this up front because the schniff's optional minimum_nights /
-	// strategy filters gate both the DM and the auto-booking call.
-	allAvailable, qerr := m.store.GetCurrentlyAvailableCampsites(ctx, req.Provider, req.CampgroundID, req.Checkin, req.Checkout)
-	if qerr != nil {
-		m.logger.Warn("get currently available campsites failed", slog.Any("err", qerr))
-	}
-
-	if !requestConditionsMet(req, allAvailable) {
-		m.logger.Info("schniff conditions not yet met; skipping notify+book",
-			slog.Int64("requestID", req.ID),
-			slog.String("userID", req.UserID),
-			slog.String("campgroundID", req.CampgroundID),
-			slog.Bool("hasMinNights", req.MinimumNights.Valid),
-			slog.Bool("hasStrategy", req.Strategy.Valid),
-		)
-		return false, nil
-	}
-
-	// Create DM channel only if we plan to send something.
-	channel, err := m.notifier.UserChannelCreate(req.UserID)
+	now time.Time,
+) []db.Notification {
+	recentHolds, err := m.store.RecentHoldOwnersForCampground(ctx, provider, campgroundID, now.Add(-recentHoldWindow))
 	if err != nil {
-		return false, err
+		m.logger.Warn("recent-hold lookup failed",
+			slog.String("provider", provider),
+			slog.String("campground", campgroundID),
+			slog.Any("err", err))
+	}
+	expiringOwners := make(map[string]string, len(recentHolds))
+	recentHeldSet := make(map[string]struct{}, len(recentHolds))
+	expiringHoldByCampsite := make(map[string]db.RecentHoldOwner, len(recentHolds))
+	for _, h := range recentHolds {
+		expiringOwners[h.CampsiteID] = h.UserID
+		recentHeldSet[h.CampsiteID] = struct{}{}
+		expiringHoldByCampsite[h.CampsiteID] = h
 	}
 
-	// HOT PATH: if the user has a warm browser session, kick off the booking
-	// attempt NOW in parallel with embed building. The goroutine posts its
-	// own "attempting" DM and result DM directly to channel.ID — we do not
-	// block the hit notification on it, and we do not block the booking on
-	// the hit notification.
-	if m.pool != nil && m.pool.HasUser(req.UserID) {
-		m.startBookingAttempt(ctx, req, newlyAvail, batchID, channel.ID)
+	prep := make([]preparedRequest, 0, len(reqIDs))
+	for _, id := range reqIDs {
+		req, ok := reqIndex[id]
+		if !ok {
+			continue
+		}
+		changes := changesByRequest[id]
+		newlyAvail, _ := separateChanges(changes)
+		if len(newlyAvail) == 0 {
+			m.logger.Info("no newly-available changes; skipping",
+				slog.Int64("requestID", req.ID),
+				slog.String("userID", req.UserID))
+			continue
+		}
+
+		allAvailable, qerr := m.store.GetCurrentlyAvailableCampsites(ctx, req.Provider, req.CampgroundID, req.Checkin, req.Checkout)
+		if qerr != nil {
+			m.logger.Warn("get currently available campsites failed", slog.Any("err", qerr))
+		}
+		if !requestConditionsMet(req, allAvailable) {
+			m.logger.Info("schniff conditions not yet met; skipping",
+				slog.Int64("requestID", req.ID),
+				slog.String("userID", req.UserID),
+				slog.Bool("hasMinNights", req.MinimumNights.Valid),
+				slog.Bool("hasStrategy", req.Strategy.Valid))
+			continue
+		}
+
+		clipped := clipToWindow(newlyAvail, req.Checkin, req.Checkout)
+		dctx, dcancel := context.WithTimeout(ctx, 5*time.Second)
+		details, _ := m.store.GetCampsiteDetailsBatch(dctx, req.Provider, req.CampgroundID, uniqueCampsiteIDs(clipped))
+		dcancel()
+		candidates := buildCandidates(clipped, details)
+
+		prep = append(prep, preparedRequest{
+			req:          req,
+			changes:      changes,
+			allAvailable: allAvailable,
+			candidates:   candidates,
+		})
 	}
 
-	byCampsite := groupAvailabilityByCampsite(allAvailable)
+	if len(prep) == 0 {
+		return nil
+	}
+
+	inputs := make([]ArbInput, len(prep))
+	for i, p := range prep {
+		inputs[i] = ArbInput{Request: p.req, Candidates: p.candidates}
+	}
+	results := Arbitrate(inputs, expiringOwners)
+
+	outcomeChan := make(chan bookOutcome, len(results))
+	expectedBooks := 0
+
+	notifs := make([]db.Notification, 0)
+	for i, r := range results {
+		p := prep[i]
+
+		for _, c := range p.changes {
+			state := "available"
+			if !c.NewAvailable {
+				state = "unavailable"
+			}
+			cc := c
+			notifs = append(notifs, db.Notification{
+				RequestID:     p.req.ID,
+				UserID:        p.req.UserID,
+				Provider:      cc.Provider,
+				CampgroundID:  cc.CampgroundID,
+				CampsiteID:    cc.CampsiteID,
+				Date:          cc.Date,
+				State:         state,
+				StateChangeID: &cc.ID,
+				SentAt:        now,
+			})
+		}
+
+		// Losers: no DM, no embed, no channel, no book. Displacement DM is
+		// sent later after winners' holds resolve.
+		if !r.Won && !r.ExpiringOwner {
+			continue
+		}
+
+		channel, cerr := m.notifier.UserChannelCreate(p.req.UserID)
+		if cerr != nil {
+			m.logger.Warn("user channel create failed",
+				slog.String("userID", p.req.UserID),
+				slog.Any("err", cerr))
+			continue
+		}
+
+		// Send the normal "site available" embed to both winners and
+		// expiring-owners. The follow-up + book decision differs below.
+		embed := m.sendAvailabilityEmbed(ctx, p)
+		if embed != nil {
+			if _, err := m.notifier.ChannelMessageSendEmbed(channel.ID, embed); err != nil {
+				m.logger.Error("failed to send notification embed",
+					slog.String("userID", p.req.UserID),
+					slog.Any("err", err))
+			}
+		}
+
+		if r.ExpiringOwner {
+			followup := fmt.Sprintf(
+				"🛒 i put site **%s** in your basket before and you didn't get it. this notification is that basket expiring. to avoid an infinite loop i'm not doing it this time.",
+				r.ExpiringOwnerPick.CampsiteID,
+			)
+			if _, err := m.notifier.ChannelMessageSend(channel.ID, followup); err != nil {
+				m.logger.Warn("send basket-expired followup failed", slog.Any("err", err))
+			}
+		}
+
+		// Auto-book + channel ping only when the user actually won a site in
+		// arbitration. An ExpiringOwner who didn't also win something else
+		// skips both. Channel is suppressed when the won site is one we
+		// recently held (i.e. the "new" availability is a cycle, not news).
+		if r.Won {
+			if _, recyc := recentHeldSet[r.Pick.CampsiteID]; !recyc {
+				m.maybeChannelBroadcast(p.req.UserID)
+			}
+			if m.pool != nil && m.pool.HasUser(p.req.UserID) {
+				expectedBooks++
+				go m.attemptHoldAndReport(ctx, p.req, r.Pick, batchID, channel.ID, outcomeChan)
+			}
+		}
+	}
+
+	outcomesByReq := make(map[int64]bookOutcome, expectedBooks)
+	for i := 0; i < expectedBooks; i++ {
+		select {
+		case <-ctx.Done():
+			i = expectedBooks
+		case o := <-outcomeChan:
+			outcomesByReq[o.winnerReqID] = o
+		}
+	}
+
+	for i, r := range results {
+		if r.Won || len(r.DisplacedBy) == 0 {
+			continue
+		}
+		successful := r.DisplacedBy[:0:0]
+		for _, d := range r.DisplacedBy {
+			if o, ok := outcomesByReq[d.WinnerReqID]; ok && o.success {
+				successful = append(successful, d)
+			}
+		}
+		if len(successful) == 0 {
+			continue
+		}
+		m.sendDisplacementDM(ctx, prep[i].req.UserID, successful)
+	}
+
+	return notifs
+}
+
+// sendAvailabilityEmbed builds the embed for a single request's currently
+// available campsites. Returns the embed (caller sends), or nil if there's
+// nothing to show. Extracted so winners and expiring-owners share the same
+// embed format.
+func (m *Manager) sendAvailabilityEmbed(ctx context.Context, p preparedRequest) *discordgo.MessageEmbed {
+	byCampsite := groupAvailabilityByCampsite(p.allAvailable)
 	campsiteIDs := collectMapKeys(byCampsite)
-	detailsMap, derr := m.store.GetCampsiteDetailsBatch(ctx, req.Provider, req.CampgroundID, campsiteIDs)
+	detailsMap, derr := m.store.GetCampsiteDetailsBatch(ctx, p.req.Provider, p.req.CampgroundID, campsiteIDs)
 	if derr != nil {
 		m.logger.Warn("GetCampsiteDetailsBatch failed; using basic details", slog.Any("err", derr))
 		detailsMap = map[string]db.CampsiteDetails{}
 	}
-	stats := buildCampsiteStats(byCampsite, req.Checkin, req.Checkout, detailsMap)
-
-	campground, _, gerr := m.store.GetCampgroundByID(ctx, req.Provider, req.CampgroundID)
+	stats := buildCampsiteStats(byCampsite, p.req.Checkin, p.req.Checkout, detailsMap)
+	campground, _, gerr := m.store.GetCampgroundByID(ctx, p.req.Provider, p.req.CampgroundID)
 	if gerr != nil {
 		m.logger.Warn("GetCampgroundByID failed; proceeding with minimal info", slog.Any("err", gerr))
 	}
-	campgroundURL := m.CampgroundURL(req.Provider, req.CampgroundID)
-	provider, _ := m.reg.Get(req.Provider)
+	campgroundURL := m.CampgroundURL(p.req.Provider, p.req.CampgroundID)
+	provider, _ := m.reg.Get(p.req.Provider)
 
 	embeds := BuildNotificationEmbeds(
-		req.Checkin, req.Checkout, req.UserID,
+		p.req.Checkin, p.req.Checkout, p.req.UserID,
 		campground.Name, campgroundURL, campground.ID,
 		stats,
 		provider,
 	)
-	actuallySent := false
 	for _, e := range embeds {
-		if e == nil {
-			continue
+		if e != nil {
+			return e
 		}
-		if _, sendErr := m.notifier.ChannelMessageSendEmbed(channel.ID, e); sendErr != nil {
-			m.logger.Error("failed to send notification embed", slog.Any("err", sendErr), slog.String("userID", req.UserID))
-			err = sendErr
-			continue
-		}
-		actuallySent = true
 	}
-	return actuallySent, err
+	return nil
 }
 
-// startBookingAttempt runs the selection + HoldCampsite call in a goroutine.
-// It sends two DMs directly to channelID: an "attempting to hold X" message
-// as soon as we have a pick, and a result message when the hold finishes.
-// The caller does not block on Discord, and the booking does not block on
-// Discord.
-func (m *Manager) startBookingAttempt(
+// maybeChannelBroadcast posts the silly broadcast to the public summary
+// channel; isolated so the bucket coordinator can suppress it when the
+// triggering availability is one of our own recent holds expiring.
+func (m *Manager) maybeChannelBroadcast(userID string) {
+	if m.summaryChannelID == "" {
+		return
+	}
+	if _, err := m.notifier.ChannelMessageSend(m.summaryChannelID, nonsense.RandomSillyBroadcast(userID)); err != nil {
+		m.logger.Warn("send channel broadcast failed", slog.Any("err", err))
+	}
+}
+
+// attemptHoldAndReport runs one HoldCampsite call synchronously and reports
+// the result back to the bucket coordinator via outcomeChan. It also sends
+// the user-facing "attempting" + result DMs directly to channelID, and
+// records the booking row to the DB — same side effects as the old
+// startBookingAttempt, just structured to return its outcome upward.
+func (m *Manager) attemptHoldAndReport(
 	ctx context.Context,
 	req db.SchniffRequest,
-	newlyAvail []db.AvailabilityItem,
+	pick booker.Pick,
 	batchID string,
 	channelID string,
+	outcomeChan chan<- bookOutcome,
 ) {
+	m.logger.Info("auto-booking attempt",
+		slog.String("user", req.UserID),
+		slog.String("provider", req.Provider),
+		slog.String("campground", req.CampgroundID),
+		slog.String("campsite", pick.CampsiteID),
+		slog.String("checkin", pick.CheckIn.Format("2006-01-02")),
+		slog.String("checkout", pick.CheckOut.Format("2006-01-02")),
+		slog.Int("nights", pick.Nights),
+		slog.Float64("rating", pick.Rating),
+		slog.String("batch_id", batchID),
+	)
+
 	go func() {
-		// Defensive clip in case state changes overlap multiple windows.
-		clipped := clipToWindow(newlyAvail, req.Checkin, req.Checkout)
-		if len(clipped) == 0 {
-			return
-		}
-
-		// Pull rating per campsite for the selection tiebreak; best-effort.
-		dctx, dcancel := context.WithTimeout(ctx, 5*time.Second)
-		ids := uniqueCampsiteIDs(clipped)
-		details, _ := m.store.GetCampsiteDetailsBatch(dctx, req.Provider, req.CampgroundID, ids)
-		dcancel()
-		candidates := buildCandidates(clipped, details)
-
-		pick, ok := booker.SelectBestPartial(candidates)
-		if !ok {
-			return
-		}
-
-		m.logger.Info("auto-booking attempt",
-			slog.String("user", req.UserID),
-			slog.String("provider", req.Provider),
-			slog.String("campground", req.CampgroundID),
-			slog.String("campsite", pick.CampsiteID),
-			slog.String("checkin", pick.CheckIn.Format("2006-01-02")),
-			slog.String("checkout", pick.CheckOut.Format("2006-01-02")),
-			slog.Int("nights", pick.Nights),
-			slog.Float64("rating", pick.Rating),
-			slog.String("batch_id", batchID),
+		msg := fmt.Sprintf("🛒 I'm attempting to hold site **%s** for you right now (%s → %s, %d night%s). I'll let you know how I go.",
+			pick.CampsiteID,
+			pick.CheckIn.Format("Mon Jan 2"),
+			pick.CheckOut.Format("Mon Jan 2"),
+			pick.Nights, pluralS(pick.Nights),
 		)
-
-		// Fire-and-forget "attempting" DM right now; nothing in the booking
-		// path waits on it.
-		go func() {
-			msg := fmt.Sprintf("🛒 I'm attempting to hold site **%s** for you right now (%s → %s, %d night%s). I'll let you know how I go.",
-				pick.CampsiteID,
-				pick.CheckIn.Format("Mon Jan 2"),
-				pick.CheckOut.Format("Mon Jan 2"),
-				pick.Nights, pluralS(pick.Nights),
-			)
-			if _, err := m.notifier.ChannelMessageSend(channelID, msg); err != nil {
-				m.logger.Warn("send attempting message failed", slog.Any("err", err))
-			}
-		}()
-
-		bctx, bcancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer bcancel()
-		res, err := m.pool.HoldCampsite(bctx, req.UserID, pick.CampsiteID, req.CampgroundID, pick.CheckIn, pick.CheckOut)
-
-		booking := db.Booking{
-			BatchID:      batchID,
-			UserID:       req.UserID,
-			Provider:     req.Provider,
-			CampgroundID: req.CampgroundID,
-			CampsiteID:   pick.CampsiteID,
-			Checkin:      pick.CheckIn,
-			Checkout:     pick.CheckOut,
-		}
-		if err != nil {
-			emsg := err.Error()
-			booking.Outcome = db.BookingOutcomeFailed
-			booking.ErrorMsg = &emsg
-		} else {
-			booking.Outcome = db.BookingOutcomeHeld
-			if res != nil && res.OrderID != "" {
-				oid := res.OrderID
-				booking.OrderID = &oid
-			}
-		}
-		recCtx, recCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if _, rerr := m.store.InsertBooking(recCtx, booking); rerr != nil {
-			m.logger.Warn("insert booking row failed", slog.Any("err", rerr))
-		}
-		recCancel()
-
-		if err != nil {
-			m.logger.Warn("auto-booking failed",
-				slog.String("user", req.UserID),
-				slog.String("campsite", pick.CampsiteID),
-				slog.Any("err", err),
-			)
-		} else {
-			oid := ""
-			if res != nil {
-				oid = res.OrderID
-			}
-			m.logger.Info("auto-booking held",
-				slog.String("user", req.UserID),
-				slog.String("campsite", pick.CampsiteID),
-				slog.String("order_id", oid),
-			)
-		}
-
-		result := formatBookingOutcome(pick, res, err)
-		if _, derr := m.notifier.ChannelMessageSend(channelID, result); derr != nil {
-			m.logger.Warn("send booking result message failed", slog.Any("err", derr))
+		if _, err := m.notifier.ChannelMessageSend(channelID, msg); err != nil {
+			m.logger.Warn("send attempting message failed", slog.Any("err", err))
 		}
 	}()
+
+	bctx, bcancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer bcancel()
+	res, err := m.pool.HoldCampsite(bctx, req.UserID, pick.CampsiteID, req.CampgroundID, pick.CheckIn, pick.CheckOut)
+
+	booking := db.Booking{
+		BatchID:      batchID,
+		UserID:       req.UserID,
+		Provider:     req.Provider,
+		CampgroundID: req.CampgroundID,
+		CampsiteID:   pick.CampsiteID,
+		Checkin:      pick.CheckIn,
+		Checkout:     pick.CheckOut,
+	}
+	if err != nil {
+		emsg := err.Error()
+		booking.Outcome = db.BookingOutcomeFailed
+		booking.ErrorMsg = &emsg
+	} else {
+		booking.Outcome = db.BookingOutcomeHeld
+		if res != nil && res.OrderID != "" {
+			oid := res.OrderID
+			booking.OrderID = &oid
+		}
+	}
+	recCtx, recCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if _, rerr := m.store.InsertBooking(recCtx, booking); rerr != nil {
+		m.logger.Warn("insert booking row failed", slog.Any("err", rerr))
+	}
+	recCancel()
+
+	if err != nil {
+		m.logger.Warn("auto-booking failed",
+			slog.String("user", req.UserID),
+			slog.String("campsite", pick.CampsiteID),
+			slog.Any("err", err))
+	} else {
+		oid := ""
+		if res != nil {
+			oid = res.OrderID
+		}
+		m.logger.Info("auto-booking held",
+			slog.String("user", req.UserID),
+			slog.String("campsite", pick.CampsiteID),
+			slog.String("order_id", oid))
+	}
+
+	result := formatBookingOutcome(pick, res, err)
+	if _, derr := m.notifier.ChannelMessageSend(channelID, result); derr != nil {
+		m.logger.Warn("send booking result message failed", slog.Any("err", derr))
+	}
+
+	outcomeChan <- bookOutcome{
+		winnerReqID:  req.ID,
+		winnerUserID: req.UserID,
+		pick:         pick,
+		success:      err == nil,
+	}
+}
+
+// sendDisplacementDM tells a user that an older schniff (lower request_id)
+// beat them to one or more sites this tick, naming the winners so the user
+// can reach out. Winner IDs are plain text — DMs from a bot can't ping
+// other users anyway, and we want recipients to know the username.
+func (m *Manager) sendDisplacementDM(ctx context.Context, userID string, displacements []DisplacementRecord) {
+	channel, err := m.notifier.UserChannelCreate(userID)
+	if err != nil {
+		m.logger.Warn("displacement DM: user channel create failed",
+			slog.String("userID", userID),
+			slog.Any("err", err))
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("👀 Heads up — a site you were watching opened up, but an older schniff got there first:\n")
+	for _, d := range displacements {
+		name := m.lookupUsername(d.WinnerUserID)
+		b.WriteString(fmt.Sprintf("• Site **%s** → **%s** created their schniff before you, so I booked it for them. It's in their basket now.\n",
+			d.CampsiteID, name))
+	}
+	if _, err := m.notifier.ChannelMessageSend(channel.ID, b.String()); err != nil {
+		m.logger.Warn("send displacement DM failed",
+			slog.String("userID", userID),
+			slog.Any("err", err))
+	}
+	_ = ctx
+}
+
+// lookupUsername returns the Discord username for userID, falling back to a
+// raw ID reference if the lookup fails. Plain text only — DMs from a bot
+// can't ping other users.
+func (m *Manager) lookupUsername(userID string) string {
+	if m.notifier == nil {
+		return userID
+	}
+	u, err := m.notifier.User(userID)
+	if err != nil || u == nil || u.Username == "" {
+		return userID
+	}
+	return u.Username
 }
 
 func formatBookingOutcome(pick booker.Pick, res *booker.HoldResult, err error) string {


### PR DESCRIPTION
## Summary
- New per-`(provider, campground)` arbitration pass before any `HoldCampsite` fires: greedy assignment by longest-booking-for-user → rating → lowest `request_id`. Two users no longer race for the same site; older schniffs win ties; if one user has a longer window the site goes to them even if newer.
- New "basket expiry" detection: when a campsite flips back to available within 20 min of one of our own `held` rows, the original holder is excluded from auto-booking it again. They get the normal availability DM plus a follow-up: "i put this in your basket before and you didn't get it. this notification is that basket expiring. to avoid an infinite loop i'm not doing it this time." Public channel ping is suppressed for these recycled-availability cases.
- Strict-displacement DM: losers who walked away empty-handed this tick get a single summary DM after the winner's hold succeeds, naming the winner by username (plain text — bot DMs can't ping other users) so they can reach out.

## Test plan
- [ ] Manually trigger an expiry cycle on the live machine and confirm: original holder gets the basket-expired DM, public channel stays quiet, second user (if any) wins arbitration and books normally.
- [ ] Two-user same-site scenario: confirm older schniff wins, newer gets the displacement DM after the hold succeeds.
- [ ] Longer-window-wins: a newer schniff with a 5-night overlap beats an older schniff with a 1-night overlap on the same site.
- [ ] Sanity: solo-user happy path (one schniff, one site) still books and pings channel as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)