### PR TITLE
fix(booker): show rec.gov error verbatim; book single weekend in full-weekend mode

### DIFF
--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -39,11 +39,6 @@ var ErrBadCredentials = errors.New("bad credentials")
 // reCAPTCHA score and requires its visible human-verification challenge.
 var ErrHumanVerification = errors.New("human verification required")
 
-// ErrSiteUnavailable is returned when rec.gov rejects the booking with a 400.
-// In practice this means the site was taken between our availability poll and
-// our POST — someone else (often another bot) got there first.
-var ErrSiteUnavailable = errors.New("site no longer available")
-
 type Config struct {
 	ProfileDir string
 	ChromePath string // empty = autodetect
@@ -312,8 +307,8 @@ func bookingResponseError(response map[string]any, orderID string) error {
 	if status < 200 || status >= 300 {
 		body, _ := json.Marshal(response)
 		slog.Warn("rec.gov booking rejected", slog.Any("status", response["status"]), slog.String("body", string(body)))
-		if int(status) == 400 {
-			return fmt.Errorf("%w (rec.gov 400)", ErrSiteUnavailable)
+		if msg, ok := response["error"].(string); ok && msg != "" {
+			return fmt.Errorf("rec.gov %v: %s", response["status"], msg)
 		}
 		return fmt.Errorf("rec.gov returned status %v: %s", response["status"], string(body))
 	}

--- a/internal/booker/selection.go
+++ b/internal/booker/selection.go
@@ -63,6 +63,65 @@ func SelectBestPartial(candidates []Candidate) (Pick, bool) {
 	return best, have
 }
 
+// SelectFirstWeekend picks the earliest Fri+Sat pair available on the same
+// campsite across the candidates. Returns a 2-night Pick (Fri checkin → Sun
+// checkout). Use this when the schniff's strategy is "full weekend" so we
+// reserve just the weekend instead of the longest contiguous run, which may
+// exceed campground max-stay or overshoot what the user wants.
+//
+// Ties (multiple campsites with the same earliest Friday) are broken by
+// higher rating, then lower CampsiteID — same as better().
+func SelectFirstWeekend(candidates []Candidate) (Pick, bool) {
+	var best Pick
+	var have bool
+	for _, c := range candidates {
+		fri, ok := earliestFridaySaturday(c.Dates)
+		if !ok {
+			continue
+		}
+		cand := Pick{
+			CampsiteID: c.CampsiteID,
+			CheckIn:    fri,
+			CheckOut:   fri.AddDate(0, 0, 2),
+			Nights:     2,
+			Rating:     c.Rating,
+		}
+		if !have || weekendBetter(cand, best) {
+			best = cand
+			have = true
+		}
+	}
+	return best, have
+}
+
+func weekendBetter(a, b Pick) bool {
+	if !a.CheckIn.Equal(b.CheckIn) {
+		return a.CheckIn.Before(b.CheckIn)
+	}
+	if a.Rating != b.Rating {
+		return a.Rating > b.Rating
+	}
+	return a.CampsiteID < b.CampsiteID
+}
+
+func earliestFridaySaturday(dates []time.Time) (time.Time, bool) {
+	set := map[time.Time]bool{}
+	for _, d := range dates {
+		set[d.UTC().Truncate(24*time.Hour)] = true
+	}
+	uniq := make([]time.Time, 0, len(set))
+	for d := range set {
+		uniq = append(uniq, d)
+	}
+	sort.Slice(uniq, func(i, j int) bool { return uniq[i].Before(uniq[j]) })
+	for _, d := range uniq {
+		if d.Weekday() == time.Friday && set[d.AddDate(0, 0, 1)] {
+			return d, true
+		}
+	}
+	return time.Time{}, false
+}
+
 // better returns true if a is preferable to b: more nights wins; ties broken
 // by higher rating, then by lower CampsiteID lexically.
 func better(a, b Pick) bool {

--- a/internal/manager/arbitration.go
+++ b/internal/manager/arbitration.go
@@ -50,6 +50,16 @@ type ArbResult struct {
 	DisplacedBy []DisplacementRecord
 }
 
+// pickForRequest applies the right selector for a request: full_weekend
+// schniffs book only the first Fri+Sat pair, everything else takes the
+// longest contiguous run.
+func pickForRequest(req db.SchniffRequest, candidates []booker.Candidate) (booker.Pick, bool) {
+	if req.Strategy.Valid && req.Strategy.String == db.StrategyFullWeekend {
+		return booker.SelectFirstWeekend(candidates)
+	}
+	return booker.SelectBestPartial(candidates)
+}
+
 // Arbitrate runs greedy global assignment over (request, campsite) pairs.
 // At each step the highest-scoring still-eligible pair wins: more nights →
 // higher rating → lower request_id. Once a campsite is taken or a request
@@ -69,7 +79,7 @@ func Arbitrate(inputs []ArbInput, expiringOwners map[string]string) []ArbResult 
 			if owner, ok := expiringOwners[c.CampsiteID]; ok && owner == in.Request.UserID {
 				continue
 			}
-			pick, ok := booker.SelectBestPartial([]booker.Candidate{c})
+			pick, ok := pickForRequest(in.Request, []booker.Candidate{c})
 			if !ok {
 				continue
 			}
@@ -112,7 +122,7 @@ func Arbitrate(inputs []ArbInput, expiringOwners map[string]string) []ArbResult 
 		// sites in their candidate pool?
 		for _, c := range in.Candidates {
 			if owner, ok := expiringOwners[c.CampsiteID]; ok && owner == in.Request.UserID {
-				pick, hasDates := booker.SelectBestPartial([]booker.Candidate{c})
+				pick, hasDates := pickForRequest(in.Request, []booker.Candidate{c})
 				r.ExpiringOwner = true
 				r.ExpiringOwnerHadCap = hasDates
 				if hasDates {

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -488,9 +488,6 @@ func formatBookingOutcome(pick booker.Pick, res *booker.HoldResult, err error) s
 			return fmt.Sprintf("⚠️ Recreation.gov requires a human verification step for site **%s**. [Open the site and finish manually](%s).",
 				pick.CampsiteID, url)
 		}
-		if errors.Is(err, booker.ErrSiteUnavailable) {
-			return fmt.Sprintf("🤖 Bot-on-bot violence: someone else grabbed site **%s** before us.", pick.CampsiteID)
-		}
 		return fmt.Sprintf("❌ Couldn't hold site **%s**: %s", pick.CampsiteID, err.Error())
 	}
 	url := ""


### PR DESCRIPTION
## Summary
- Drop the blanket 400 → \"Bot-on-bot violence\" mapping. Not every 400 is a lost race — today's failure was actually a 14-night max-stay violation on a 21-night attempt. Now the rec.gov error string (\"Update not allowed - The maximum consecutive length of stay is 14 nights...\") is shown to the user verbatim, and the full body is still WARN-logged.
- When the schniff strategy is `full_weekend`, arbitration picks the **earliest Fri+Sat pair** on a candidate campsite (2-night Fri→Sun hold) instead of the longest contiguous run. The availability gate already requires a Fri+Sat to fire, so this only changes the booked range, not which schniffs fire.

## Test plan
- [ ] Trigger an auto-book on a known-unavailable site; Discord shows the actual rec.gov error message.
- [ ] Set up a weekend-mode schniff; when it fires confirm the hold is exactly Fri→Sun on the earliest weekend in the window.
- [ ] Non-weekend schniff still books the longest contiguous run as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)