### PR TITLE
fix(booker): detect silent JWT expiry and re-login before holding

### DIFF
--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -39,6 +39,13 @@ var ErrBadCredentials = errors.New("bad credentials")
 // reCAPTCHA score and requires its visible human-verification challenge.
 var ErrHumanVerification = errors.New("human verification required")
 
+// ErrNotLoggedIn is returned by HoldCampsite when the session's JWT
+// ('recaccount' in localStorage) has been cleared by rec.gov — typically a
+// silent server-side session expiry. Chrome is still alive, but a fresh
+// Login is required before the booking script will succeed. The pool catches
+// this, relaunches, and retries once.
+var ErrNotLoggedIn = errors.New("not logged in")
+
 type Config struct {
 	ProfileDir string
 	ChromePath string // empty = autodetect
@@ -231,6 +238,20 @@ func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID str
 		nil, chromedp.WithPollingTimeout(30*time.Second),
 	)); err != nil {
 		return nil, fmt.Errorf("wait recaptcha: %w", err)
+	}
+	// Verify the JWT is still in localStorage before we burn a reCAPTCHA
+	// token. rec.gov silently clears 'recaccount' on session expiry while
+	// Chrome stays alive, so the chromedp ctx check in the pool is not
+	// sufficient — surface this as ErrNotLoggedIn so the pool can re-login
+	// and retry.
+	var hasAccount bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(
+		`!!(window.localStorage.getItem('recaccount'))`, &hasAccount,
+	)); err != nil {
+		return nil, fmt.Errorf("check session: %w", err)
+	}
+	if !hasAccount {
+		return nil, ErrNotLoggedIn
 	}
 	nightMap := map[string]map[string]string{}
 	for day := checkIn; day.Before(checkOut); day = day.AddDate(0, 0, 1) {

--- a/internal/booker/pool.go
+++ b/internal/booker/pool.go
@@ -162,6 +162,20 @@ func (p *Pool) Close() {
 // underlying Chrome has died (chromedp ctx cancelled), the session is
 // transparently relaunched and the booking proceeds on the fresh session.
 func (p *Pool) HoldCampsite(ctx context.Context, userID, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
+	res, err := p.holdOnce(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
+	if !errors.Is(err, ErrNotLoggedIn) {
+		return res, err
+	}
+	// Session JWT expired silently. Force a full relaunch (login) and try
+	// once more on the fresh session.
+	p.cfg.Logger.Warn("hold: session not logged in; relaunching and retrying", "user", userID)
+	if relaunchErr := p.launchUser(ctx, userID); relaunchErr != nil {
+		return nil, fmt.Errorf("relaunch after session expiry: %w", relaunchErr)
+	}
+	return p.holdOnce(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
+}
+
+func (p *Pool) holdOnce(ctx context.Context, userID, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
 	e, err := p.ensureAlive(ctx, userID)
 	if err != nil {
 		return nil, err
@@ -289,17 +303,25 @@ func (p *Pool) watchdogSweep(ctx context.Context) {
 		pa.e.mu.Unlock()
 		if !dead {
 			// Also do a quick liveness ping so we catch hung browsers
-			// (chromedp ctx not yet cancelled but Chrome unresponsive).
+			// (chromedp ctx not yet cancelled but Chrome unresponsive),
+			// and verify the JWT is still in localStorage so we catch
+			// silent server-side session expiry before the next booking.
 			pa.e.mu.Lock()
 			pingCtx, pingCancel := context.WithTimeout(pa.e.session.Ctx(), 3*time.Second)
-			var v bool
-			perr := chromedp.Run(pingCtx, chromedp.Evaluate(`true`, &v))
+			var loggedIn bool
+			perr := chromedp.Run(pingCtx, chromedp.Evaluate(
+				`!!(window.localStorage.getItem('recaccount'))`, &loggedIn,
+			))
 			pingCancel()
 			pa.e.mu.Unlock()
-			if perr == nil {
+			if perr == nil && loggedIn {
 				continue
 			}
-			p.cfg.Logger.Warn("watchdog: session ping failed; will relaunch", "user", pa.id, "err", perr)
+			if perr != nil {
+				p.cfg.Logger.Warn("watchdog: session ping failed; will relaunch", "user", pa.id, "err", perr)
+			} else {
+				p.cfg.Logger.Warn("watchdog: session not logged in; will relaunch", "user", pa.id)
+			}
 		} else {
 			p.cfg.Logger.Warn("watchdog: session dead; will relaunch", "user", pa.id)
 		}


### PR DESCRIPTION
## Summary
- rec.gov silently clears the \`recaccount\` JWT in localStorage; the booking script then threw \`no recaccount in localStorage\` (seen in prod: \"Couldn't hold site 329: exec booking: exception ...\").
- \`Session.HoldCampsite\` now verifies the JWT after nav and returns a new \`ErrNotLoggedIn\` sentinel before burning a reCAPTCHA token.
- \`Pool.HoldCampsite\` retries once after a full relaunch (which re-logs in); the watchdog now pings \`localStorage.getItem('recaccount')\` instead of \`true\` so expired sessions get refreshed between bookings.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/booker/...\`
- [ ] Deploy to 192.168.1.22 and confirm next auto-book attempt either succeeds or relogs and retries without surfacing the localStorage error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)