### PR TITLE
fix(manager): fastestPoll back to 5s

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -127,11 +127,12 @@ func (m *Manager) runExpiryReaper(ctx context.Context) {
 	}
 }
 
-// fastestPoll is the floor for the provider poll cadence. 5s lands well
-// inside the GCP Cloud Run free tier (see docs/auto-booking.md "Polling
-// cost analysis") and roughly halves the latency from rec.gov flipping
-// availability to schniffer noticing.
-const fastestPoll = 2 * time.Second
+// fastestPoll is the floor for the provider poll cadence. 5s keeps us
+// safely under recreation.gov's per-IP throttle — at 2s we saw immediate
+// 100% 429s when traffic was funnelled through a single CF Worker egress
+// pool (see PR #32 revert). The ticker change still gives a tighter
+// effective cadence than the old time.After loop at the same value.
+const fastestPoll = 5 * time.Second
 
 // pollBackoffStep is added to the interval each time a cycle returns an
 // error; the next success resets to fastestPoll. Keeps backoff linear so


### PR DESCRIPTION
PR #30 dropped \`fastestPoll\` from 5s to 2s on the assumption we were moving to Cloudflare. PR #32 reverted the endpoint list back to Cloud Run but didn't revert the cadence — at 2s on Cloud Run we'd risk a different rate-limit pattern (per Google AS this time). Bringing it back to 5s now that we're back on Cloud Run.

The ticker change from PR #30 stays — even at 5s, the new loop fires on schedule rather than sleeping after each cycle, so effective cadence is ~5s rather than ~5.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)