### PR TITLE
feat(booker): per-schniff warm tabs + path-tagged outcome

### DIFF
--- a/cmd/booker-bench/main.go
+++ b/cmd/booker-bench/main.go
@@ -131,14 +131,14 @@ func main() {
 }
 
 type iterRecord struct {
-	Scenario string                 `json:"scenario"`
-	SiteID   string                 `json:"site_id"`
-	Date     string                 `json:"date"`
-	Wall     time.Duration          `json:"wall_ns"` // wall clock for the on-demand portion only (no prewarm)
-	Timings  booker.HoldTimings     `json:"timings"`
-	OrderID  string                 `json:"order_id,omitempty"`
-	Err      string                 `json:"err,omitempty"`
-	Raw      map[string]any         `json:"-"`
+	Scenario string             `json:"scenario"`
+	SiteID   string             `json:"site_id"`
+	Date     string             `json:"date"`
+	Wall     time.Duration      `json:"wall_ns"` // wall clock for the on-demand portion only (no prewarm)
+	Timings  booker.HoldTimings `json:"timings"`
+	OrderID  string             `json:"order_id,omitempty"`
+	Err      string             `json:"err,omitempty"`
+	Raw      map[string]any     `json:"-"`
 }
 
 func runCold(sess *booker.Session, cg string, n, nights int, pause time.Duration, slot func() (string, time.Time)) []iterRecord {
@@ -213,9 +213,9 @@ func runWarm1(sess *booker.Session, cg string, n, nights int, pause time.Duratio
 func runWarmN(sess *booker.Session, cg string, tabs, n, nights int, pause time.Duration, slot func() (string, time.Time)) ([]iterRecord, error) {
 	// Open N tabs, each prewarmed on a distinct site. Reuse slots round-robin.
 	type tabState struct {
-		tab     *booker.Tab
-		siteID  string
-		date    time.Time
+		tab    *booker.Tab
+		siteID string
+		date   time.Time
 	}
 	states := make([]*tabState, 0, tabs)
 	for i := 0; i < tabs; i++ {

--- a/cmd/booker-bench/main.go
+++ b/cmd/booker-bench/main.go
@@ -1,0 +1,399 @@
+// booker-bench measures different chromedp booking strategies against
+// rec.gov so we can identify where wall-clock time is spent and how much
+// of it is pre-payable via warm tabs.
+//
+// Scenarios:
+//
+//	cold:   one tab, full Session.HoldCampsite each iteration (current prod).
+//	warm1:  one tab, PrewarmCampsite once, then HoldFast each iteration.
+//	warmN:  N tabs, each prewarmed on a different campsite, HoldFast per tab.
+//
+// Each iteration consumes a fresh (site, date) pair so the 15-min auto-expiring
+// holds never collide. By default the test target is Baker Dam (10085599) — 18
+// sites, all open July 2026 (probed live before running).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/brensch/schniffer/internal/booker"
+)
+
+func main() {
+	var (
+		campground = flag.String("campground", "10085599", "test campground ID (default Baker Dam)")
+		monthStart = flag.String("month", "2026-07-01", "month to pull availability from (YYYY-MM-01)")
+		nights     = flag.Int("nights", 1, "nights per hold")
+		iter       = flag.Int("iter", 8, "iterations per scenario")
+		tabs       = flag.Int("tabs", 3, "tabs for warmN scenario")
+		scenarios  = flag.String("scenarios", "cold,warm1,warmN", "comma-separated subset of {cold,warm1,warmN}")
+		profileDir = flag.String("profile", "", "Chrome user-data-dir (default ~/.cache/recgov-booker)")
+		chromePath = flag.String("chrome", "", "chrome binary (default autodetect)")
+		debugDir   = flag.String("debug-dir", "/tmp/booker-bench", "debug dump dir")
+		pause      = flag.Duration("pause", 1*time.Second, "pause between iterations")
+	)
+	flag.Parse()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	email := os.Getenv("REC_GOV_EMAIL")
+	password := os.Getenv("REC_GOV_PASSWORD")
+	if email == "" || password == "" {
+		fatal("REC_GOV_EMAIL and REC_GOV_PASSWORD must be set")
+	}
+	if *profileDir == "" {
+		home, _ := os.UserHomeDir()
+		*profileDir = filepath.Join(home, ".cache", "recgov-booker")
+	}
+	_ = os.MkdirAll(*debugDir, 0o755)
+
+	// Step 1: pull available (site, date) tuples.
+	month, err := time.Parse("2006-01-02", *monthStart)
+	if err != nil {
+		fatal("bad -month: %v", err)
+	}
+	pool, err := fetchAvailableSlots(context.Background(), *campground, month)
+	if err != nil {
+		fatal("fetch availability: %v", err)
+	}
+	if len(pool) == 0 {
+		fatal("no available (site,date) slots for cg %s in %s", *campground, *monthStart)
+	}
+	slog.Info("availability fetched", "slots", len(pool))
+	rand.Shuffle(len(pool), func(i, j int) { pool[i], pool[j] = pool[j], pool[i] })
+
+	// Step 2: open Chrome + log in.
+	sess, err := booker.Open(booker.Config{ProfileDir: *profileDir, ChromePath: *chromePath})
+	if err != nil {
+		fatal("open chrome: %v", err)
+	}
+	defer sess.Close()
+	loginCtx, loginCancel := context.WithTimeout(sess.Ctx(), 90*time.Second)
+	if err := sess.Login(loginCtx, email, password); err != nil {
+		loginCancel()
+		fatal("login: %v", err)
+	}
+	loginCancel()
+	slog.Info("logged in")
+
+	// Step 3: run scenarios.
+	want := map[string]bool{}
+	for _, s := range strings.Split(*scenarios, ",") {
+		want[strings.TrimSpace(s)] = true
+	}
+	results := map[string][]iterRecord{}
+	slot := func() (string, time.Time) {
+		if len(pool) == 0 {
+			fatal("ran out of slots")
+		}
+		s := pool[0]
+		pool = pool[1:]
+		return s.siteID, s.date
+	}
+
+	if want["cold"] {
+		slog.Info("scenario cold start")
+		recs := runCold(sess, *campground, *iter, *nights, *pause, slot)
+		results["cold"] = recs
+	}
+	if want["warm1"] {
+		slog.Info("scenario warm1 start")
+		recs, err := runWarm1(sess, *campground, *iter, *nights, *pause, slot)
+		if err != nil {
+			slog.Error("warm1 failed", "err", err)
+		}
+		results["warm1"] = recs
+	}
+	if want["warmN"] {
+		slog.Info("scenario warmN start", "tabs", *tabs)
+		recs, err := runWarmN(sess, *campground, *tabs, *iter, *nights, *pause, slot)
+		if err != nil {
+			slog.Error("warmN failed", "err", err)
+		}
+		results["warmN"] = recs
+	}
+
+	// Step 4: report.
+	report(results, *debugDir)
+}
+
+type iterRecord struct {
+	Scenario string                 `json:"scenario"`
+	SiteID   string                 `json:"site_id"`
+	Date     string                 `json:"date"`
+	Wall     time.Duration          `json:"wall_ns"` // wall clock for the on-demand portion only (no prewarm)
+	Timings  booker.HoldTimings     `json:"timings"`
+	OrderID  string                 `json:"order_id,omitempty"`
+	Err      string                 `json:"err,omitempty"`
+	Raw      map[string]any         `json:"-"`
+}
+
+func runCold(sess *booker.Session, cg string, n, nights int, pause time.Duration, slot func() (string, time.Time)) []iterRecord {
+	recs := make([]iterRecord, 0, n)
+	for i := 0; i < n; i++ {
+		siteID, date := slot()
+		depart := date.AddDate(0, 0, nights)
+		ctx, cancel := context.WithTimeout(sess.Ctx(), 90*time.Second)
+		start := time.Now()
+		res, err := sess.HoldCampsite(ctx, siteID, cg, date, depart)
+		wall := time.Since(start)
+		cancel()
+		rec := iterRecord{Scenario: "cold", SiteID: siteID, Date: date.Format("2006-01-02"), Wall: wall}
+		if res != nil {
+			rec.Timings = res.Timings
+			rec.OrderID = res.OrderID
+		}
+		if err != nil {
+			rec.Err = err.Error()
+		}
+		slog.Info("cold iter", "i", i, "site", siteID, "date", rec.Date, "wall", wall, "err", rec.Err)
+		recs = append(recs, rec)
+		time.Sleep(pause)
+	}
+	return recs
+}
+
+func runWarm1(sess *booker.Session, cg string, n, nights int, pause time.Duration, slot func() (string, time.Time)) ([]iterRecord, error) {
+	// Pre-warm on the FIRST site we'll book. Subsequent iterations will
+	// re-prewarm on each new site, but we measure only HoldFast wall.
+	recs := make([]iterRecord, 0, n)
+	tab, err := sess.NewTab()
+	if err != nil {
+		return nil, err
+	}
+	defer tab.Close()
+	for i := 0; i < n; i++ {
+		siteID, date := slot()
+		depart := date.AddDate(0, 0, nights)
+		// Pre-warm (out-of-band, not counted in Wall).
+		pctx, pcancel := context.WithTimeout(tab.Ctx(), 60*time.Second)
+		pt, perr := booker.PrewarmCampsite(pctx, siteID)
+		pcancel()
+		if perr != nil {
+			slog.Warn("warm1 prewarm failed", "err", perr)
+			recs = append(recs, iterRecord{Scenario: "warm1", SiteID: siteID, Date: date.Format("2006-01-02"), Err: perr.Error()})
+			continue
+		}
+		// Now measure the on-demand HoldFast.
+		hctx, hcancel := context.WithTimeout(tab.Ctx(), 60*time.Second)
+		start := time.Now()
+		res, err := booker.HoldFast(hctx, siteID, cg, date, depart)
+		wall := time.Since(start)
+		hcancel()
+		rec := iterRecord{Scenario: "warm1", SiteID: siteID, Date: date.Format("2006-01-02"), Wall: wall}
+		if res != nil {
+			rec.Timings = res.Timings
+			rec.Timings.Nav = pt.Nav
+			rec.Timings.RecaptchaWait = pt.RecaptchaWait
+			rec.OrderID = res.OrderID
+		}
+		if err != nil {
+			rec.Err = err.Error()
+		}
+		slog.Info("warm1 iter", "i", i, "site", siteID, "date", rec.Date, "wall", wall, "prewarm_nav", pt.Nav, "err", rec.Err)
+		recs = append(recs, rec)
+		time.Sleep(pause)
+	}
+	return recs, nil
+}
+
+func runWarmN(sess *booker.Session, cg string, tabs, n, nights int, pause time.Duration, slot func() (string, time.Time)) ([]iterRecord, error) {
+	// Open N tabs, each prewarmed on a distinct site. Reuse slots round-robin.
+	type tabState struct {
+		tab     *booker.Tab
+		siteID  string
+		date    time.Time
+	}
+	states := make([]*tabState, 0, tabs)
+	for i := 0; i < tabs; i++ {
+		t, err := sess.NewTab()
+		if err != nil {
+			return nil, fmt.Errorf("open tab %d: %w", i, err)
+		}
+		siteID, date := slot()
+		pctx, pcancel := context.WithTimeout(t.Ctx(), 60*time.Second)
+		if _, err := booker.PrewarmCampsite(pctx, siteID); err != nil {
+			pcancel()
+			t.Close()
+			return nil, fmt.Errorf("prewarm tab %d: %w", i, err)
+		}
+		pcancel()
+		states = append(states, &tabState{tab: t, siteID: siteID, date: date})
+		slog.Info("warmN tab ready", "tab", i, "site", siteID)
+	}
+	defer func() {
+		for _, s := range states {
+			s.tab.Close()
+		}
+	}()
+
+	recs := make([]iterRecord, 0, n)
+	for i := 0; i < n; i++ {
+		st := states[i%len(states)]
+		// Use the slot this tab was already prewarmed for the first time it
+		// is hit; afterwards prewarm a fresh slot on this tab (which counts
+		// nav+recaptcha against future iterations, but those aren't part of
+		// Wall — they happen out-of-band).
+		siteID, date := st.siteID, st.date
+		depart := date.AddDate(0, 0, nights)
+		hctx, hcancel := context.WithTimeout(st.tab.Ctx(), 60*time.Second)
+		start := time.Now()
+		res, err := booker.HoldFast(hctx, siteID, cg, date, depart)
+		wall := time.Since(start)
+		hcancel()
+		rec := iterRecord{Scenario: "warmN", SiteID: siteID, Date: date.Format("2006-01-02"), Wall: wall}
+		if res != nil {
+			rec.Timings = res.Timings
+			rec.OrderID = res.OrderID
+		}
+		if err != nil {
+			rec.Err = err.Error()
+		}
+		slog.Info("warmN iter", "i", i, "tab", i%len(states), "site", siteID, "wall", wall, "err", rec.Err)
+		recs = append(recs, rec)
+		// Re-prewarm this tab for its next turn on a fresh slot.
+		newSite, newDate := slot()
+		pctx, pcancel := context.WithTimeout(st.tab.Ctx(), 60*time.Second)
+		if _, perr := booker.PrewarmCampsite(pctx, newSite); perr != nil {
+			slog.Warn("warmN re-prewarm failed", "tab", i%len(states), "err", perr)
+		} else {
+			st.siteID, st.date = newSite, newDate
+		}
+		pcancel()
+		time.Sleep(pause)
+	}
+	return recs, nil
+}
+
+func report(results map[string][]iterRecord, debugDir string) {
+	fmt.Println()
+	fmt.Println("=== booker-bench results ===")
+	names := []string{"cold", "warm1", "warmN"}
+	for _, name := range names {
+		recs, ok := results[name]
+		if !ok || len(recs) == 0 {
+			continue
+		}
+		var walls, navs, recs2, sess2, scripts, tokens, posts []time.Duration
+		var ok2, errs int
+		for _, r := range recs {
+			walls = append(walls, r.Wall)
+			navs = append(navs, r.Timings.Nav)
+			recs2 = append(recs2, r.Timings.RecaptchaWait)
+			sess2 = append(sess2, r.Timings.SessionCheck)
+			scripts = append(scripts, r.Timings.ScriptEval)
+			tokens = append(tokens, r.Timings.RecaptchaToken)
+			posts = append(posts, r.Timings.RecGovPost)
+			if r.Err == "" {
+				ok2++
+			} else {
+				errs++
+			}
+		}
+		fmt.Printf("\n[%s]  n=%d  ok=%d  err=%d\n", name, len(recs), ok2, errs)
+		printRow("wall (on-demand)", walls)
+		printRow("  nav            ", navs)
+		printRow("  recaptcha wait ", recs2)
+		printRow("  session check  ", sess2)
+		printRow("  script eval    ", scripts)
+		printRow("    recap token  ", tokens)
+		printRow("    recgov post  ", posts)
+	}
+	// Dump raw records too.
+	out := filepath.Join(debugDir, fmt.Sprintf("bench-%d.json", time.Now().Unix()))
+	f, err := os.Create(out)
+	if err == nil {
+		defer f.Close()
+		enc := json.NewEncoder(f)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(results)
+		fmt.Printf("\nRaw records: %s\n", out)
+	}
+}
+
+func printRow(label string, ds []time.Duration) {
+	sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+	if len(ds) == 0 {
+		return
+	}
+	p := func(q float64) time.Duration {
+		if len(ds) == 0 {
+			return 0
+		}
+		i := int(float64(len(ds)-1) * q)
+		return ds[i]
+	}
+	fmt.Printf("  %s  p50=%-8s p95=%-8s max=%-8s\n", label, fmtDur(p(0.5)), fmtDur(p(0.95)), fmtDur(p(1.0)))
+}
+
+func fmtDur(d time.Duration) string {
+	if d == 0 {
+		return "—"
+	}
+	return d.Round(time.Millisecond).String()
+}
+
+// availability helpers
+
+type slotInfo struct {
+	siteID string
+	date   time.Time
+}
+
+func fetchAvailableSlots(ctx context.Context, cg string, month time.Time) ([]slotInfo, error) {
+	base, _ := url.Parse(fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", cg))
+	q := base.Query()
+	q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z"))
+	base.RawQuery = q.Encode()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 booker-bench")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("availability status %d: %s", resp.StatusCode, string(body))
+	}
+	var parsed struct {
+		Campsites map[string]struct {
+			Availabilities map[string]string `json:"availabilities"`
+		} `json:"campsites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+	var out []slotInfo
+	for siteID, sd := range parsed.Campsites {
+		for dateStr, status := range sd.Availabilities {
+			if status != "Available" {
+				continue
+			}
+			d, err := time.Parse(time.RFC3339, dateStr)
+			if err != nil {
+				continue
+			}
+			out = append(out, slotInfo{siteID: siteID, date: d})
+		}
+	}
+	return out, nil
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "fatal: "+strings.TrimRight(format, "\n")+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/booker-stability/main.go
+++ b/cmd/booker-stability/main.go
@@ -1,0 +1,329 @@
+// booker-stability holds a prewarmed tab on a campsite page and fires a
+// HoldFast every -interval, rotating through fresh (site, date) slots.
+//
+// Goal: confirm steady-state behaviour over long windows — does the SPA
+// stay healthy, the JWT survive, the grecaptcha bindings stay callable, and
+// the on-demand wall time stay flat? If anything degrades, the run prints a
+// recovery (re-prewarm) and continues.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/brensch/schniffer/internal/booker"
+)
+
+func main() {
+	var (
+		campground = flag.String("campground", "10085599", "test campground ID")
+		monthStart = flag.String("month", "2026-07-01", "month YYYY-MM-01")
+		nights     = flag.Int("nights", 1, "nights per hold")
+		interval   = flag.Duration("interval", 3*time.Minute, "delay between holds")
+		runFor     = flag.Duration("for", 60*time.Minute, "total wall-clock budget")
+		profileDir = flag.String("profile", "", "Chrome profile dir")
+		chromePath = flag.String("chrome", "", "Chrome binary")
+		debugDir   = flag.String("debug-dir", "/tmp/booker-stability", "debug dump dir")
+	)
+	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	email := os.Getenv("REC_GOV_EMAIL")
+	password := os.Getenv("REC_GOV_PASSWORD")
+	if email == "" || password == "" {
+		fatal("REC_GOV_EMAIL and REC_GOV_PASSWORD must be set")
+	}
+	if *profileDir == "" {
+		home, _ := os.UserHomeDir()
+		*profileDir = filepath.Join(home, ".cache", "recgov-booker")
+	}
+	_ = os.MkdirAll(*debugDir, 0o755)
+
+	month, err := time.Parse("2006-01-02", *monthStart)
+	if err != nil {
+		fatal("bad -month: %v", err)
+	}
+	slots, err := fetchAvailableSlots(context.Background(), *campground, month)
+	if err != nil {
+		fatal("fetch availability: %v", err)
+	}
+	if len(slots) < 5 {
+		fatal("not enough slots (%d)", len(slots))
+	}
+	rand.Shuffle(len(slots), func(i, j int) { slots[i], slots[j] = slots[j], slots[i] })
+	slog.Info("availability fetched", "slots", len(slots))
+
+	sess, err := booker.Open(booker.Config{ProfileDir: *profileDir, ChromePath: *chromePath})
+	if err != nil {
+		fatal("open chrome: %v", err)
+	}
+	defer sess.Close()
+	loginCtx, loginCancel := context.WithTimeout(sess.Ctx(), 90*time.Second)
+	if err := sess.Login(loginCtx, email, password); err != nil {
+		loginCancel()
+		fatal("login: %v", err)
+	}
+	loginCancel()
+	slog.Info("logged in")
+
+	tab, err := sess.NewTab()
+	if err != nil {
+		fatal("new tab: %v", err)
+	}
+	defer tab.Close()
+
+	var records []record
+
+	deadline := time.Now().Add(*runFor)
+	// Group dates by siteID so when we rotate the date we stay on a
+	// (site, date) tuple rec.gov has actually marked Available.
+	bySite := map[string][]time.Time{}
+	for _, s := range slots {
+		bySite[s.siteID] = append(bySite[s.siteID], s.date)
+	}
+	pickSiteWithDates := func(min int) (string, []time.Time) {
+		for sid, ds := range bySite {
+			if len(ds) >= min {
+				return sid, ds
+			}
+		}
+		return "", nil
+	}
+	curSite, curSiteDates := pickSiteWithDates(5)
+	if curSite == "" {
+		fatal("no site has at least 5 available dates")
+	}
+	delete(bySite, curSite)
+	rand.Shuffle(len(curSiteDates), func(i, j int) { curSiteDates[i], curSiteDates[j] = curSiteDates[j], curSiteDates[i] })
+	nextDate := func() time.Time {
+		if len(curSiteDates) == 0 {
+			// Rotate to a fresh site if we exhaust the current site's dates.
+			ns, nd := pickSiteWithDates(1)
+			if ns == "" {
+				return time.Time{}
+			}
+			curSite, curSiteDates = ns, nd
+			delete(bySite, ns)
+			rand.Shuffle(len(curSiteDates), func(i, j int) { curSiteDates[i], curSiteDates[j] = curSiteDates[j], curSiteDates[i] })
+		}
+		d := curSiteDates[0]
+		curSiteDates = curSiteDates[1:]
+		return d
+	}
+	_ = slots // not used after this point
+	pctx, pcancel := context.WithTimeout(tab.Ctx(), 60*time.Second)
+	if _, err := booker.PrewarmCampsite(pctx, curSite); err != nil {
+		pcancel()
+		fatal("initial prewarm: %v", err)
+	}
+	pcancel()
+	slog.Info("initial prewarm done", "site", curSite)
+
+	iter := 0
+	recoverNext := false
+	for time.Now().Before(deadline) {
+		iter++
+		date := nextDate()
+		if date.IsZero() {
+			slog.Warn("ran out of (site,date) tuples; stopping early")
+			break
+		}
+		depart := date.AddDate(0, 0, *nights)
+		hctx, hcancel := context.WithTimeout(tab.Ctx(), 60*time.Second)
+		start := time.Now()
+		res, err := booker.HoldFast(hctx, curSite, *campground, date, depart)
+		wall := time.Since(start)
+		hcancel()
+		rec := record{
+			Iter: iter, At: time.Now(), Site: curSite, Date: date.Format("2006-01-02"),
+			Prewarmed: true, WallMs: wall.Milliseconds(),
+			Recovered: recoverNext,
+		}
+		if res != nil {
+			rec.PostMs = res.Timings.RecGovPost.Milliseconds()
+			rec.TokenMs = res.Timings.RecaptchaToken.Milliseconds()
+		}
+		recoverNext = false
+		// "modification already in cart" and "popular site already reserved"
+		// are *not* infrastructure failures — recaptcha minted, the POST
+		// reached rec.gov, and the server replied within wall time. They
+		// mean the test target accumulated state (e.g., from a previous
+		// run). Count the latency, mark the row, but don't trigger recovery.
+		if err != nil && (strings.Contains(err.Error(), "modification already in cart") || strings.Contains(err.Error(), "popular site")) {
+			rec.Err = err.Error()
+			slog.Info("iter ok (server rejected w/ benign 400)", "iter", iter, "wall", wall, "err", err)
+			records = append(records, rec)
+			select { case <-time.After(*interval): }
+			continue
+		}
+		if err != nil {
+			rec.Err = err.Error()
+			slog.Warn("iter failed", "iter", iter, "err", err, "wall", wall)
+			// Recover: rotate to a fresh site so we keep going.
+			ns, nd := pickSiteWithDates(1)
+			if ns == "" {
+				slog.Error("no fresh site to recover onto; stopping")
+				break
+			}
+			curSite, curSiteDates = ns, nd
+			delete(bySite, ns)
+			rand.Shuffle(len(curSiteDates), func(i, j int) { curSiteDates[i], curSiteDates[j] = curSiteDates[j], curSiteDates[i] })
+			pctx, pcancel := context.WithTimeout(tab.Ctx(), 60*time.Second)
+			if _, perr := booker.PrewarmCampsite(pctx, curSite); perr != nil {
+				slog.Error("recovery prewarm failed; reopening tab", "err", perr)
+				tab.Close()
+				tab, err = sess.NewTab()
+				if err != nil {
+					slog.Error("re-open tab failed", "err", err)
+					break
+				}
+				pctx2, pcancel2 := context.WithTimeout(tab.Ctx(), 60*time.Second)
+				if _, perr := booker.PrewarmCampsite(pctx2, curSite); perr != nil {
+					slog.Error("post-reopen prewarm failed", "err", perr)
+					pcancel2()
+					break
+				}
+				pcancel2()
+			}
+			pcancel()
+			recoverNext = true
+		} else {
+			slog.Info("iter ok", "iter", iter, "wall", wall, "site", curSite, "date", rec.Date)
+		}
+		records = append(records, rec)
+		// Pace.
+		select {
+		case <-time.After(*interval):
+		}
+	}
+
+	out := filepath.Join(*debugDir, fmt.Sprintf("stability-%d.json", time.Now().Unix()))
+	if f, err := os.Create(out); err == nil {
+		defer f.Close()
+		enc := json.NewEncoder(f)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(records)
+	}
+	summarize(records)
+	fmt.Println("raw:", out)
+}
+
+func summarize(records []record) {
+	var oks, benign400s, infraErrs int
+	var walls []int64
+	for _, r := range records {
+		switch {
+		case r.Err == "":
+			oks++
+			walls = append(walls, r.WallMs)
+		case strings.Contains(r.Err, "modification already in cart"), strings.Contains(r.Err, "popular site"):
+			benign400s++
+			walls = append(walls, r.WallMs) // still a real round trip
+		default:
+			infraErrs++
+		}
+	}
+	errs := infraErrs
+	fmt.Println()
+	fmt.Println("=== stability summary ===")
+	fmt.Printf("iters: %d  ok: %d  benign400: %d  infra_err: %d\n", len(records), oks, benign400s, errs)
+	if len(walls) > 0 {
+		var sum int64
+		for _, w := range walls {
+			sum += w
+		}
+		fmt.Printf("wall (ok only) mean=%dms first=%dms last=%dms\n", sum/int64(len(walls)), walls[0], walls[len(walls)-1])
+		// drift check: median of first quartile vs last quartile
+		q := len(walls) / 4
+		if q > 0 {
+			var early, late int64
+			for i := 0; i < q; i++ {
+				early += walls[i]
+				late += walls[len(walls)-1-i]
+			}
+			fmt.Printf("wall first-quartile-mean=%dms  last-quartile-mean=%dms  (drift = %+dms)\n",
+				early/int64(q), late/int64(q), late/int64(q)-early/int64(q))
+		}
+	}
+	for _, r := range records {
+		if r.Err != "" {
+			fmt.Printf("  err iter=%d at=%s: %s\n", r.Iter, r.At.Format("15:04:05"), r.Err)
+		}
+	}
+}
+
+type record struct {
+	Iter      int       `json:"iter"`
+	At        time.Time `json:"at"`
+	Site      string    `json:"site"`
+	Date      string    `json:"date"`
+	Prewarmed bool      `json:"prewarmed"`
+	WallMs    int64     `json:"wall_ms"`
+	PostMs    int64     `json:"post_ms"`
+	TokenMs   int64     `json:"token_ms"`
+	Err       string    `json:"err,omitempty"`
+	Recovered bool      `json:"recovered,omitempty"`
+}
+
+// availability helpers
+
+type slotInfo struct {
+	siteID string
+	date   time.Time
+}
+
+func fetchAvailableSlots(ctx context.Context, cg string, month time.Time) ([]slotInfo, error) {
+	base, _ := url.Parse(fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", cg))
+	q := base.Query()
+	q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z"))
+	base.RawQuery = q.Encode()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 booker-stability")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+	var parsed struct {
+		Campsites map[string]struct {
+			Availabilities map[string]string `json:"availabilities"`
+		} `json:"campsites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+	var out []slotInfo
+	for siteID, sd := range parsed.Campsites {
+		for dateStr, status := range sd.Availabilities {
+			if status != "Available" {
+				continue
+			}
+			d, err := time.Parse(time.RFC3339, dateStr)
+			if err != nil {
+				continue
+			}
+			out = append(out, slotInfo{siteID: siteID, date: d})
+		}
+	}
+	return out, nil
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "fatal: "+strings.TrimRight(format, "\n")+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/booker-stability/main.go
+++ b/cmd/booker-stability/main.go
@@ -164,7 +164,9 @@ func main() {
 			rec.Err = err.Error()
 			slog.Info("iter ok (server rejected w/ benign 400)", "iter", iter, "wall", wall, "err", err)
 			records = append(records, rec)
-			select { case <-time.After(*interval): }
+			select {
+			case <-time.After(*interval):
+			}
 			continue
 		}
 		if err != nil {

--- a/cmd/booker-warmtab-test/main.go
+++ b/cmd/booker-warmtab-test/main.go
@@ -1,0 +1,214 @@
+// booker-warmtab-test exercises the per-schniff warm-tab path end-to-end
+// against real rec.gov so we can confirm:
+//
+//  1. Pool.EnsureWarmTabForRequest opens + navigates a dedicated tab.
+//  2. Pool.HoldOnRequestTab on the same campsiteID hits the fast path
+//     (HoldFast) and a 400 with the in-page perf markers is still a
+//     successful round-trip from the latency perspective.
+//  3. A second HoldOnRequestTab with a different campsiteID navigates the
+//     tab and still completes.
+//  4. CloseRequestTab leaves the underlying session healthy for a
+//     follow-up call that uses the main tab (HoldCampsite fallback).
+//
+// It picks two fresh (site, date) tuples from Baker Dam to avoid colliding
+// with the user's accumulated cart holds. Output is the booking_phase log
+// stream — grep on correlation_id to read one booking at a time.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/brensch/schniffer/internal/booker"
+)
+
+func main() {
+	var (
+		campground = flag.String("campground", "10085599", "test campground ID (Baker Dam default)")
+		monthStart = flag.String("month", "2026-08-01", "month YYYY-MM-01")
+		nights     = flag.Int("nights", 1, "nights per hold")
+		profileDir = flag.String("profile", "", "Chrome profile dir (default ~/.cache/recgov-booker)")
+		chromePath = flag.String("chrome", "", "Chrome binary")
+	)
+	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	email := os.Getenv("REC_GOV_EMAIL")
+	password := os.Getenv("REC_GOV_PASSWORD")
+	if email == "" || password == "" {
+		fatal("REC_GOV_EMAIL and REC_GOV_PASSWORD must be set")
+	}
+	if *profileDir == "" {
+		home, _ := os.UserHomeDir()
+		*profileDir = filepath.Join(home, ".cache", "recgov-booker")
+	}
+
+	month, err := time.Parse("2006-01-02", *monthStart)
+	if err != nil {
+		fatal("bad -month: %v", err)
+	}
+	slots, err := fetchAvailableSlots(context.Background(), *campground, month)
+	if err != nil {
+		fatal("availability: %v", err)
+	}
+	if len(slots) < 4 {
+		fatal("need at least 4 slots; got %d", len(slots))
+	}
+	rand.Shuffle(len(slots), func(i, j int) { slots[i], slots[j] = slots[j], slots[i] })
+
+	// Find two distinct campsites that each have at least one available date.
+	siteA := slots[0]
+	var siteB slotInfo
+	for _, s := range slots[1:] {
+		if s.siteID != siteA.siteID {
+			siteB = s
+			break
+		}
+	}
+	if siteB.siteID == "" {
+		fatal("could not find two distinct sites with availability")
+	}
+	slog.Info("selected test sites", "site_a", siteA.siteID, "site_b", siteB.siteID)
+
+	// Pool with one user (us). Credentials are looked up via env.
+	const fakeUserID = "warmtab-test"
+	pool := booker.NewPool(booker.PoolConfig{
+		BaseProfileDir: filepath.Dir(*profileDir),
+		ChromePath:     *chromePath,
+		LookupCredential: func(ctx context.Context, _ string) (string, string, error) {
+			return email, password, nil
+		},
+		Logger: slog.Default(),
+	})
+	// Profile-dir layout: pool keys per-user-id, so we need our env profile
+	// to land at <BaseProfileDir>/<userID>.
+	src := *profileDir
+	dst := filepath.Join(filepath.Dir(*profileDir), fakeUserID)
+	if src != dst {
+		// Best-effort: if the user already pointed BaseProfileDir to the
+		// right parent, src==dst and there's nothing to do. Otherwise
+		// just warn — we don't move user dirs around silently.
+		slog.Info("pool will look up profile at", "path", dst, "you passed", src)
+	}
+	if err := pool.StartUser(context.Background(), fakeUserID); err != nil {
+		fatal("pool warmup: %v", err)
+	}
+	defer pool.Close()
+	slog.Info("pool warm")
+
+	const reqID = int64(424242)
+
+	// Step 1: ensure warm tab on siteA.
+	ectx, ecancel := context.WithTimeout(context.Background(), 60*time.Second)
+	if err := pool.EnsureWarmTabForRequest(ectx, fakeUserID, reqID, siteA.siteID); err != nil {
+		ecancel()
+		fatal("ensure warm tab (siteA): %v", err)
+	}
+	ecancel()
+	slog.Info("=== step 1 ok: warm tab on siteA ===", "site", siteA.siteID)
+
+	// Step 2: HoldOnRequestTab on siteA → fast path.
+	bctx, bcancel := context.WithTimeout(context.Background(), 60*time.Second)
+	res, err := pool.HoldOnRequestTab(bctx, fakeUserID, reqID, siteA.siteID, *campground, siteA.date, siteA.date.AddDate(0, 0, *nights))
+	bcancel()
+	slog.Info("=== step 2 result ===", "wall", durationFromRaw(res), "err", errString(err), "order", orderID(res))
+
+	// Step 3: HoldOnRequestTab on siteB → mismatch path (tab navigates).
+	bctx2, bcancel2 := context.WithTimeout(context.Background(), 90*time.Second)
+	res2, err2 := pool.HoldOnRequestTab(bctx2, fakeUserID, reqID, siteB.siteID, *campground, siteB.date, siteB.date.AddDate(0, 0, *nights))
+	bcancel2()
+	slog.Info("=== step 3 result ===", "wall", durationFromRaw(res2), "err", errString(err2), "order", orderID(res2))
+
+	// Step 4: close the warm tab.
+	pool.CloseRequestTab(fakeUserID, reqID)
+	slog.Info("=== step 4 ok: warm tab closed ===")
+
+	// Step 5: a normal HoldCampsite on the main session still works (we
+	// fall back to the same path the legacy code used).
+	bctx3, bcancel3 := context.WithTimeout(context.Background(), 90*time.Second)
+	res3, err3 := pool.HoldOnRequestTab(bctx3, fakeUserID, reqID, siteA.siteID, *campground, siteA.date.AddDate(0, 0, 7), siteA.date.AddDate(0, 0, 7+*nights))
+	bcancel3()
+	slog.Info("=== step 5 result (fallback path; no warm tab) ===", "wall", durationFromRaw(res3), "err", errString(err3), "order", orderID(res3))
+}
+
+func durationFromRaw(r *booker.HoldResult) time.Duration {
+	if r == nil {
+		return 0
+	}
+	return r.Timings.Total
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func orderID(r *booker.HoldResult) string {
+	if r == nil {
+		return ""
+	}
+	return r.OrderID
+}
+
+type slotInfo struct {
+	siteID string
+	date   time.Time
+}
+
+func fetchAvailableSlots(ctx context.Context, cg string, month time.Time) ([]slotInfo, error) {
+	base, _ := url.Parse(fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", cg))
+	q := base.Query()
+	q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z"))
+	base.RawQuery = q.Encode()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 booker-warmtab-test")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+	var parsed struct {
+		Campsites map[string]struct {
+			Availabilities map[string]string `json:"availabilities"`
+		} `json:"campsites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+	var out []slotInfo
+	for siteID, sd := range parsed.Campsites {
+		for dateStr, status := range sd.Availabilities {
+			if status != "Available" {
+				continue
+			}
+			d, err := time.Parse(time.RFC3339, dateStr)
+			if err != nil {
+				continue
+			}
+			out = append(out, slotInfo{siteID: siteID, date: d})
+		}
+	}
+	return out, nil
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "fatal: "+strings.TrimRight(format, "\n")+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/booker-warmtab-test/main.go
+++ b/cmd/booker-warmtab-test/main.go
@@ -1,16 +1,16 @@
 // booker-warmtab-test exercises the per-schniff warm-tab path end-to-end
 // against real rec.gov so we can confirm:
 //
-//  1. Pool.EnsureWarmTabForRequest opens + navigates a dedicated tab.
-//  2. Pool.HoldOnRequestTab on the same campsiteID hits the fast path
-//     (HoldFast) and a 400 with the in-page perf markers is still a
-//     successful round-trip from the latency perspective.
-//  3. A second HoldOnRequestTab with a different campsiteID navigates the
-//     tab and still completes.
-//  4. CloseRequestTab leaves the underlying session healthy for a
+//  1. Pool.EnsureWarmTabForRequest opens + navigates a dedicated tab on
+//     the campground page.
+//  2. Pool.HoldOnRequestTab hits the fast path (HoldFast) for one campsite,
+//     and crucially ALSO hits the fast path for a DIFFERENT campsite in
+//     the same campground — no re-navigation required because the tab is
+//     parked at the campground level.
+//  3. CloseRequestTab leaves the underlying session healthy for a
 //     follow-up call that uses the main tab (HoldCampsite fallback).
 //
-// It picks two fresh (site, date) tuples from Baker Dam to avoid colliding
+// Picks two fresh (site, date) tuples from Baker Dam to avoid colliding
 // with the user's accumulated cart holds. Output is the booking_phase log
 // stream — grep on correlation_id to read one booking at a time.
 package main
@@ -36,7 +36,7 @@ import (
 func main() {
 	var (
 		campground = flag.String("campground", "10085599", "test campground ID (Baker Dam default)")
-		monthStart = flag.String("month", "2026-08-01", "month YYYY-MM-01")
+		monthStart = flag.String("month", "2026-09-01", "month YYYY-MM-01")
 		nights     = flag.Int("nights", 1, "nights per hold")
 		profileDir = flag.String("profile", "", "Chrome profile dir (default ~/.cache/recgov-booker)")
 		chromePath = flag.String("chrome", "", "Chrome binary")
@@ -67,7 +67,6 @@ func main() {
 	}
 	rand.Shuffle(len(slots), func(i, j int) { slots[i], slots[j] = slots[j], slots[i] })
 
-	// Find two distinct campsites that each have at least one available date.
 	siteA := slots[0]
 	var siteB slotInfo
 	for _, s := range slots[1:] {
@@ -81,7 +80,6 @@ func main() {
 	}
 	slog.Info("selected test sites", "site_a", siteA.siteID, "site_b", siteB.siteID)
 
-	// Pool with one user (us). Credentials are looked up via env.
 	const fakeUserID = "warmtab-test"
 	pool := booker.NewPool(booker.PoolConfig{
 		BaseProfileDir: filepath.Dir(*profileDir),
@@ -91,16 +89,6 @@ func main() {
 		},
 		Logger: slog.Default(),
 	})
-	// Profile-dir layout: pool keys per-user-id, so we need our env profile
-	// to land at <BaseProfileDir>/<userID>.
-	src := *profileDir
-	dst := filepath.Join(filepath.Dir(*profileDir), fakeUserID)
-	if src != dst {
-		// Best-effort: if the user already pointed BaseProfileDir to the
-		// right parent, src==dst and there's nothing to do. Otherwise
-		// just warn — we don't move user dirs around silently.
-		slog.Info("pool will look up profile at", "path", dst, "you passed", src)
-	}
 	if err := pool.StartUser(context.Background(), fakeUserID); err != nil {
 		fatal("pool warmup: %v", err)
 	}
@@ -109,40 +97,55 @@ func main() {
 
 	const reqID = int64(424242)
 
-	// Step 1: ensure warm tab on siteA.
+	// Step 1: ensure warm tab on the CAMPGROUND page (not a campsite).
 	ectx, ecancel := context.WithTimeout(context.Background(), 60*time.Second)
-	if err := pool.EnsureWarmTabForRequest(ectx, fakeUserID, reqID, siteA.siteID); err != nil {
+	if err := pool.EnsureWarmTabForRequest(ectx, fakeUserID, reqID, *campground); err != nil {
 		ecancel()
-		fatal("ensure warm tab (siteA): %v", err)
+		fatal("ensure warm tab on campground: %v", err)
 	}
 	ecancel()
-	slog.Info("=== step 1 ok: warm tab on siteA ===", "site", siteA.siteID)
+	slog.Info("=== step 1 ok: warm tab on campground page ===", "campground", *campground)
 
-	// Step 2: HoldOnRequestTab on siteA → fast path.
+	// Step 2: HoldOnRequestTab for siteA → fast path.
 	bctx, bcancel := context.WithTimeout(context.Background(), 60*time.Second)
 	res, err := pool.HoldOnRequestTab(bctx, fakeUserID, reqID, siteA.siteID, *campground, siteA.date, siteA.date.AddDate(0, 0, *nights))
 	bcancel()
-	slog.Info("=== step 2 result ===", "wall", durationFromRaw(res), "err", errString(err), "order", orderID(res))
+	slog.Info("=== step 2 result (siteA on warm tab) ===",
+		"path", pathOf(res), "wall", wallOf(res), "err", errString(err), "order", orderID(res))
 
-	// Step 3: HoldOnRequestTab on siteB → mismatch path (tab navigates).
-	bctx2, bcancel2 := context.WithTimeout(context.Background(), 90*time.Second)
+	// Step 3: HoldOnRequestTab for siteB → ALSO fast path (no re-nav).
+	// This is the critical assertion: the warm tab is on the campground
+	// page, so it serves any campsite in the campground equally well.
+	bctx2, bcancel2 := context.WithTimeout(context.Background(), 60*time.Second)
 	res2, err2 := pool.HoldOnRequestTab(bctx2, fakeUserID, reqID, siteB.siteID, *campground, siteB.date, siteB.date.AddDate(0, 0, *nights))
 	bcancel2()
-	slog.Info("=== step 3 result ===", "wall", durationFromRaw(res2), "err", errString(err2), "order", orderID(res2))
+	slog.Info("=== step 3 result (siteB on SAME warm tab) ===",
+		"path", pathOf(res2), "wall", wallOf(res2), "err", errString(err2), "order", orderID(res2))
+	if pathOf(res2) != "warm_tab_fast" {
+		slog.Error("REGRESSION: step 3 took the slow path despite warm tab being parked on the campground",
+			"path", pathOf(res2))
+	}
 
 	// Step 4: close the warm tab.
 	pool.CloseRequestTab(fakeUserID, reqID)
 	slog.Info("=== step 4 ok: warm tab closed ===")
 
-	// Step 5: a normal HoldCampsite on the main session still works (we
-	// fall back to the same path the legacy code used).
+	// Step 5: a fallback HoldOnRequestTab without warm tab still works.
 	bctx3, bcancel3 := context.WithTimeout(context.Background(), 90*time.Second)
 	res3, err3 := pool.HoldOnRequestTab(bctx3, fakeUserID, reqID, siteA.siteID, *campground, siteA.date.AddDate(0, 0, 7), siteA.date.AddDate(0, 0, 7+*nights))
 	bcancel3()
-	slog.Info("=== step 5 result (fallback path; no warm tab) ===", "wall", durationFromRaw(res3), "err", errString(err3), "order", orderID(res3))
+	slog.Info("=== step 5 result (fallback path; no warm tab) ===",
+		"path", pathOf(res3), "wall", wallOf(res3), "err", errString(err3), "order", orderID(res3))
 }
 
-func durationFromRaw(r *booker.HoldResult) time.Duration {
+func pathOf(r *booker.HoldResult) string {
+	if r == nil {
+		return ""
+	}
+	return string(r.Path)
+}
+
+func wallOf(r *booker.HoldResult) time.Duration {
 	if r == nil {
 		return 0
 	}

--- a/cmd/recaptcha-probe/main.go
+++ b/cmd/recaptcha-probe/main.go
@@ -1,0 +1,163 @@
+// recaptcha-probe checks which rec.gov SPA routes have
+// grecaptcha.enterprise.execute defined, and (when so) whether a HoldFast
+// call from that page actually succeeds against the rec.gov POST. If the
+// campground overview accepts the hold, we can park one warm tab per
+// schniff there and never re-navigate per campsite.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/brensch/schniffer/internal/booker"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	home, _ := os.UserHomeDir()
+	sess, err := booker.Open(booker.Config{ProfileDir: filepath.Join(home, ".cache", "recgov-booker")})
+	if err != nil {
+		die("open: %v", err)
+	}
+	defer sess.Close()
+	ctx, cancel := context.WithTimeout(sess.Ctx(), 180*time.Second)
+	defer cancel()
+	if err := sess.Login(ctx, os.Getenv("REC_GOV_EMAIL"), os.Getenv("REC_GOV_PASSWORD")); err != nil {
+		die("login: %v", err)
+	}
+
+	// Pick a fresh (siteID, date) for Baker Dam so we can try a real POST.
+	month, _ := time.Parse("2006-01-02", "2026-09-01")
+	slots, err := fetchAvailableSlots(ctx, "10085599", month)
+	if err != nil || len(slots) == 0 {
+		die("availability: %v", err)
+	}
+	rand.Shuffle(len(slots), func(i, j int) { slots[i], slots[j] = slots[j], slots[i] })
+	target := slots[0]
+	fmt.Printf("test target: siteID=%s date=%s\n\n", target.siteID, target.date.Format("2006-01-02"))
+
+	cases := []struct{ label, url string }{
+		{"campground overview", "https://www.recreation.gov/camping/campgrounds/10085599"},
+		{"campsite page (control)", fmt.Sprintf("https://www.recreation.gov/camping/campsites/%s", target.siteID)},
+		{"homepage", "https://www.recreation.gov/"},
+	}
+	for _, c := range cases {
+		probeWithRealHold(ctx, c.label, c.url, target.siteID, "10085599", target.date)
+	}
+}
+
+func probeWithRealHold(ctx context.Context, label, u, campsiteID, campgroundID string, date time.Time) {
+	fmt.Printf("=== %s (%s) ===\n", label, u)
+	navStart := time.Now()
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(u),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		fmt.Printf("  NAV FAILED: %v\n\n", err)
+		return
+	}
+	fmt.Printf("  nav: %s\n", time.Since(navStart).Round(time.Millisecond))
+
+	pStart := time.Now()
+	if err := chromedp.Run(ctx, chromedp.Poll(
+		`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
+		nil, chromedp.WithPollingTimeout(15*time.Second),
+	)); err != nil {
+		fmt.Printf("  recaptcha NEVER LOADED (%s)\n\n", time.Since(pStart).Round(time.Millisecond))
+		return
+	}
+	fmt.Printf("  recaptcha ready: %s\n", time.Since(pStart).Round(time.Millisecond))
+
+	// Run the booking script: mint token + POST. Adapted from booker.HoldFast.
+	checkOut := date.AddDate(0, 0, 1)
+	const iso = "2006-01-02T00:00:00.000Z"
+	nightMap := map[string]map[string]string{
+		date.UTC().Format(iso): {"campsite_id": campsiteID, "campsite_loop": "", "campsite_name": ""},
+	}
+	payload := map[string]any{
+		"campsiteID":   campsiteID,
+		"campgroundID": campgroundID,
+		"checkIn":      date.UTC().Format(iso),
+		"checkOut":     checkOut.UTC().Format(iso),
+		"nightMap":     nightMap,
+		"siteKey":      booker.RecaptchaSiteKey,
+		"action":       booker.RecaptchaAction,
+	}
+	pb, _ := json.Marshal(payload)
+	script := `(async (p) => {
+		const _t0 = performance.now();
+		const token = await grecaptcha.enterprise.execute(p.siteKey, {action: p.action});
+		const _tokenMs = performance.now() - _t0;
+		const recRaw = window.localStorage.getItem('recaccount');
+		if (!recRaw) throw new Error('no recaccount in localStorage');
+		const rec = JSON.parse(recRaw);
+		const body = {
+			reservations: [{
+				account_id: rec.account.account_id,
+				campsite_id: p.campsiteID,
+				check_in: p.checkIn,
+				check_out: p.checkOut,
+				reservation_options: {night_map: p.nightMap, recommendation_referrer: 'campground-vnull:campsitePage'},
+			}],
+			gate_a: {value: token, description: p.action, success: true, terminal: 'east'},
+		};
+		const _postStart = performance.now();
+		const r = await fetch('/api/camps/reservations/campgrounds/' + p.campgroundID + '/multi', {
+			method: 'POST',
+			headers: {'content-type': 'application/json', 'authorization': 'Bearer ' + rec.access_token},
+			body: JSON.stringify(body),
+			credentials: 'include',
+		});
+		const text = await r.text();
+		const _postMs = performance.now() - _postStart;
+		let parsed; try { parsed = JSON.parse(text); } catch (_) { parsed = {raw: text}; }
+		return {status: r.status, _tokenMs, _postMs, ...parsed};
+	})(` + string(pb) + `)`
+	var out map[string]any
+	holdStart := time.Now()
+	if err := chromedp.Run(ctx, chromedp.Evaluate(script, &out, func(p *runtime.EvaluateParams) *runtime.EvaluateParams { return p.WithAwaitPromise(true) })); err != nil {
+		fmt.Printf("  SCRIPT FAILED: %v\n\n", err)
+		return
+	}
+	wall := time.Since(holdStart)
+	fmt.Printf("  hold wall: %s  (token=%.0fms post=%.0fms)\n",
+		wall.Round(time.Millisecond), out["_tokenMs"], out["_postMs"])
+	status := out["status"]
+	res, _ := json.Marshal(out)
+	if oid := booker.ExtractOrderID(out); oid != "" {
+		fmt.Printf("  STATUS=%v order_id=%s ✓ HELD\n", status, oid)
+	} else {
+		fmt.Printf("  STATUS=%v  body=%s\n", status, truncate(string(res), 240))
+	}
+	fmt.Println()
+}
+
+func truncate(s string, n int) string { if len(s) > n { return s[:n] + "…" }; return s }
+
+type slotInfo struct{ siteID string; date time.Time }
+func fetchAvailableSlots(ctx context.Context, cg string, month time.Time) ([]slotInfo, error) {
+	base, _ := url.Parse(fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", cg))
+	q := base.Query(); q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z")); base.RawQuery = q.Encode()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	resp, err := http.DefaultClient.Do(req); if err != nil { return nil, err }; defer resp.Body.Close()
+	if resp.StatusCode != 200 { body, _ := io.ReadAll(resp.Body); return nil, fmt.Errorf("%d %s", resp.StatusCode, body) }
+	var parsed struct{ Campsites map[string]struct{ Availabilities map[string]string `json:"availabilities"` } `json:"campsites"` }
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil { return nil, err }
+	var out []slotInfo
+	for s, d := range parsed.Campsites { for dt, st := range d.Availabilities { if st == "Available" { t, _ := time.Parse(time.RFC3339, dt); out = append(out, slotInfo{s, t}) } } }
+	return out, nil
+}
+
+func die(format string, args ...any) { fmt.Fprintf(os.Stderr, "fatal: "+format+"\n", args...); os.Exit(1) }

--- a/cmd/recaptcha-probe/main.go
+++ b/cmd/recaptcha-probe/main.go
@@ -143,21 +143,55 @@ func probeWithRealHold(ctx context.Context, label, u, campsiteID, campgroundID s
 	fmt.Println()
 }
 
-func truncate(s string, n int) string { if len(s) > n { return s[:n] + "…" }; return s }
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}
 
-type slotInfo struct{ siteID string; date time.Time }
+type slotInfo struct {
+	siteID string
+	date   time.Time
+}
+
 func fetchAvailableSlots(ctx context.Context, cg string, month time.Time) ([]slotInfo, error) {
 	base, _ := url.Parse(fmt.Sprintf("https://www.recreation.gov/api/camps/availability/campground/%s/month", cg))
-	q := base.Query(); q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z")); base.RawQuery = q.Encode()
+	q := base.Query()
+	q.Set("start_date", month.UTC().Format("2006-01-02T15:04:05.000Z"))
+	base.RawQuery = q.Encode()
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), nil)
 	req.Header.Set("User-Agent", "Mozilla/5.0")
-	resp, err := http.DefaultClient.Do(req); if err != nil { return nil, err }; defer resp.Body.Close()
-	if resp.StatusCode != 200 { body, _ := io.ReadAll(resp.Body); return nil, fmt.Errorf("%d %s", resp.StatusCode, body) }
-	var parsed struct{ Campsites map[string]struct{ Availabilities map[string]string `json:"availabilities"` } `json:"campsites"` }
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil { return nil, err }
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%d %s", resp.StatusCode, body)
+	}
+	var parsed struct {
+		Campsites map[string]struct {
+			Availabilities map[string]string `json:"availabilities"`
+		} `json:"campsites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
 	var out []slotInfo
-	for s, d := range parsed.Campsites { for dt, st := range d.Availabilities { if st == "Available" { t, _ := time.Parse(time.RFC3339, dt); out = append(out, slotInfo{s, t}) } } }
+	for s, d := range parsed.Campsites {
+		for dt, st := range d.Availabilities {
+			if st == "Available" {
+				t, _ := time.Parse(time.RFC3339, dt)
+				out = append(out, slotInfo{s, t})
+			}
+		}
+	}
 	return out, nil
 }
 
-func die(format string, args ...any) { fmt.Fprintf(os.Stderr, "fatal: "+format+"\n", args...); os.Exit(1) }
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "fatal: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -223,6 +223,54 @@ type HoldResult struct {
 	// Each duration is zero if the corresponding phase never started (e.g.
 	// nav failed before recaptcha wait).
 	Timings HoldTimings
+	// Path names which Pool execution branch produced this result. Set by
+	// Pool.HoldOnRequestTab so the manager can tell the user (and the log
+	// stream) whether the fast warm-tab path won the race or we had to
+	// fall back to a full nav.
+	Path HoldPath
+}
+
+// HoldPath enumerates which Pool branch ran the hold. The manager surfaces
+// this in the booking result DM and in the auto-booking log line so an
+// operator can tell at a glance whether the warm-tab plumbing actually
+// kicked in for this attempt.
+type HoldPath string
+
+const (
+	// HoldPathWarmTabFast: dedicated warm tab was on the exact campsite —
+	// HoldFast skipped Nav + recaptcha wait. Floor case (~1.15s).
+	HoldPathWarmTabFast HoldPath = "warm_tab_fast"
+	// HoldPathWarmTabNav: dedicated warm tab existed but was parked on a
+	// different campsite than the one we needed; we navigated and ran
+	// the full HoldCampsite on the same warm Chrome. Saves browser
+	// boot/login cost vs main session, not Nav itself.
+	HoldPathWarmTabNav HoldPath = "warm_tab_nav"
+	// HoldPathMainSession: no warm tab was registered for this schniff
+	// (e.g. the reconcile loop hasn't ticked yet, or the user has no
+	// active auto-book schniffs). Fell through to the all-in-one
+	// HoldCampsite on the main session.
+	HoldPathMainSession HoldPath = "main_session"
+	// HoldPathRelaunchRetry: the warm tab's session JWT silently
+	// expired; Pool relaunched (re-login) and replayed the hold against
+	// the fresh session.
+	HoldPathRelaunchRetry HoldPath = "relaunch_retry"
+)
+
+// Human returns a short tag suitable for the user-facing booking DM.
+func (h HoldPath) Human() string {
+	switch h {
+	case HoldPathWarmTabFast:
+		return "⚡ warm tab (fast path)"
+	case HoldPathWarmTabNav:
+		return "🟡 warm tab + re-nav"
+	case HoldPathMainSession:
+		return "🐌 cold start (no warm tab)"
+	case HoldPathRelaunchRetry:
+		return "♻️ relaunch + retry"
+	case "":
+		return ""
+	}
+	return string(h)
 }
 
 // HoldTimings carries fine-grained latency breakdown for one HoldCampsite call.
@@ -247,31 +295,38 @@ func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID str
 	if !checkIn.Before(checkOut) {
 		return nil, errors.New("check-in must be before check-out")
 	}
-	var t HoldTimings
+	t := &HoldTimings{}
 	totalStart := time.Now()
-	defer func() {
+	// finalize: must run before each return that builds a HoldResult, so
+	// the embedded Timings.Total is meaningful (value copy at return time).
+	finalize := func() {
 		t.Total = time.Since(totalStart)
-	}()
+		logPhase(ctx, "hold_total", totalStart, t.Total, nil)
+	}
 
 	navStart := time.Now()
-	if err := chromedp.Run(ctx,
+	navErr := chromedp.Run(ctx,
 		chromedp.Navigate(fmt.Sprintf("%s/camping/campsites/%s", SiteOrigin, campsiteID)),
 		chromedp.WaitReady("body", chromedp.ByQuery),
-	); err != nil {
-		t.Nav = time.Since(navStart)
-		return &HoldResult{Timings: t}, fmt.Errorf("nav: %w", err)
-	}
+	)
 	t.Nav = time.Since(navStart)
+	logPhase(ctx, "nav", navStart, t.Nav, navErr)
+	if navErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("nav: %w", navErr)
+	}
 
 	recaptchaStart := time.Now()
-	if err := chromedp.Run(ctx, chromedp.Poll(
+	recErr := chromedp.Run(ctx, chromedp.Poll(
 		`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
 		nil, chromedp.WithPollingTimeout(30*time.Second),
-	)); err != nil {
-		t.RecaptchaWait = time.Since(recaptchaStart)
-		return &HoldResult{Timings: t}, fmt.Errorf("wait recaptcha: %w", err)
-	}
+	))
 	t.RecaptchaWait = time.Since(recaptchaStart)
+	logPhase(ctx, "recaptcha_wait", recaptchaStart, t.RecaptchaWait, recErr)
+	if recErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("wait recaptcha: %w", recErr)
+	}
 
 	// Verify the JWT is still in localStorage before we burn a reCAPTCHA
 	// token. rec.gov silently clears 'recaccount' on session expiry while
@@ -280,15 +335,18 @@ func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID str
 	// and retry.
 	sessionStart := time.Now()
 	var hasAccount bool
-	if err := chromedp.Run(ctx, chromedp.Evaluate(
+	sErr := chromedp.Run(ctx, chromedp.Evaluate(
 		`!!(window.localStorage.getItem('recaccount'))`, &hasAccount,
-	)); err != nil {
-		t.SessionCheck = time.Since(sessionStart)
-		return &HoldResult{Timings: t}, fmt.Errorf("check session: %w", err)
-	}
+	))
 	t.SessionCheck = time.Since(sessionStart)
+	logPhase(ctx, "session_check", sessionStart, t.SessionCheck, sErr)
+	if sErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("check session: %w", sErr)
+	}
 	if !hasAccount {
-		return &HoldResult{Timings: t}, ErrNotLoggedIn
+		finalize()
+		return &HoldResult{Timings: *t}, ErrNotLoggedIn
 	}
 	nightMap := map[string]map[string]string{}
 	for day := checkIn; day.Before(checkOut); day = day.AddDate(0, 0, 1) {
@@ -355,14 +413,23 @@ func (s *Session) HoldCampsite(ctx context.Context, campsiteID, campgroundID str
 	var out map[string]any
 	awaitOpt := func(p *runtime.EvaluateParams) *runtime.EvaluateParams { return p.WithAwaitPromise(true) }
 	scriptStart := time.Now()
-	if err := chromedp.Run(ctx, chromedp.Evaluate(script, &out, awaitOpt)); err != nil {
-		t.ScriptEval = time.Since(scriptStart)
-		return &HoldResult{Timings: t}, fmt.Errorf("exec booking: %w", err)
-	}
+	scriptErr := chromedp.Run(ctx, chromedp.Evaluate(script, &out, awaitOpt))
 	t.ScriptEval = time.Since(scriptStart)
+	logPhase(ctx, "script_eval", scriptStart, t.ScriptEval, scriptErr)
+	if scriptErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("exec booking: %w", scriptErr)
+	}
 	t.RecaptchaToken = readMillis(out, "_recaptcha_token_ms")
 	t.RecGovPost = readMillis(out, "_recgov_post_ms")
-	result := &HoldResult{OrderID: ExtractOrderID(out), Raw: out, Timings: t}
+	if t.RecaptchaToken > 0 {
+		logPhase(ctx, "recaptcha_token_mint", scriptStart, t.RecaptchaToken, nil)
+	}
+	if t.RecGovPost > 0 {
+		logPhase(ctx, "recgov_post", scriptStart.Add(t.RecaptchaToken), t.RecGovPost, nil)
+	}
+	finalize()
+	result := &HoldResult{OrderID: ExtractOrderID(out), Raw: out, Timings: *t}
 	if err := bookingResponseError(out, result.OrderID); err != nil {
 		return result, err
 	}

--- a/internal/booker/booker.go
+++ b/internal/booker/booker.go
@@ -237,22 +237,20 @@ type HoldResult struct {
 type HoldPath string
 
 const (
-	// HoldPathWarmTabFast: dedicated warm tab was on the exact campsite —
-	// HoldFast skipped Nav + recaptcha wait. Floor case (~1.15s).
+	// HoldPathWarmTabFast: dedicated warm tab was parked on the schniff's
+	// campground page; HoldFast skipped Nav + recaptcha wait entirely.
+	// Floor case (~1.15s = recaptcha mint + rec.gov POST).
 	HoldPathWarmTabFast HoldPath = "warm_tab_fast"
-	// HoldPathWarmTabNav: dedicated warm tab existed but was parked on a
-	// different campsite than the one we needed; we navigated and ran
-	// the full HoldCampsite on the same warm Chrome. Saves browser
-	// boot/login cost vs main session, not Nav itself.
-	HoldPathWarmTabNav HoldPath = "warm_tab_nav"
 	// HoldPathMainSession: no warm tab was registered for this schniff
-	// (e.g. the reconcile loop hasn't ticked yet, or the user has no
-	// active auto-book schniffs). Fell through to the all-in-one
-	// HoldCampsite on the main session.
+	// (e.g. the reconcile loop hasn't ticked yet, the user has no active
+	// auto-book schniffs, or — rare — the schniff's campground changed
+	// mid-flight). Fell through to the all-in-one HoldCampsite on the
+	// main session.
 	HoldPathMainSession HoldPath = "main_session"
 	// HoldPathRelaunchRetry: the warm tab's session JWT silently
 	// expired; Pool relaunched (re-login) and replayed the hold against
-	// the fresh session.
+	// the fresh session. Warm tabs are rebuilt by the reconcile loop on
+	// its next tick.
 	HoldPathRelaunchRetry HoldPath = "relaunch_retry"
 )
 
@@ -261,8 +259,6 @@ func (h HoldPath) Human() string {
 	switch h {
 	case HoldPathWarmTabFast:
 		return "⚡ warm tab (fast path)"
-	case HoldPathWarmTabNav:
-		return "🟡 warm tab + re-nav"
 	case HoldPathMainSession:
 		return "🐌 cold start (no warm tab)"
 	case HoldPathRelaunchRetry:

--- a/internal/booker/pool.go
+++ b/internal/booker/pool.go
@@ -45,9 +45,31 @@ type Pool struct {
 }
 
 type entry struct {
-	mu       sync.Mutex // serializes operations on this session (one Chrome window, one nav at a time)
+	mu       sync.Mutex // serializes operations on the session's main tab.
 	session  *Session
 	disabled bool
+	// prewarmedSite is the campsiteID currently navigated + recaptcha-ready
+	// on this session's main tab. "" means no prewarm or stale (we cleared
+	// it after the last booking POST). HoldCampsiteFast uses this to decide
+	// whether it can skip the ~1.1s nav.
+	prewarmedSite string
+
+	// tabsMu guards the schniff-tabs map. Tabs themselves are independent
+	// chromedp contexts; each has its own mutex (warmTab.mu) so per-tab
+	// operations don't serialize with each other or with the main tab.
+	tabsMu sync.Mutex
+	tabs   map[int64]*warmTab // keyed by schniff_request.id
+}
+
+// warmTab is a dedicated Chrome tab pre-navigated to a specific campsite
+// page for one active schniff request. The tab stays alive for the
+// schniff's lifetime so HoldCampsite on this tab pays no Nav or recaptcha
+// load cost — just session_check + script_eval.
+type warmTab struct {
+	mu     sync.Mutex // serializes Prewarm + Hold on this tab
+	tab    *Tab
+	site   string // last campsite the tab was navigated to
+	closed bool
 }
 
 func NewPool(cfg PoolConfig) *Pool {
@@ -112,8 +134,11 @@ func (p *Pool) launchUser(ctx context.Context, userID string) error {
 	old, existed := p.sessions[userID]
 	p.sessions[userID] = &entry{session: sess}
 	p.mu.Unlock()
-	if existed && old != nil && old.session != nil {
-		old.session.Close()
+	if existed && old != nil {
+		closeEntryTabs(old)
+		if old.session != nil {
+			old.session.Close()
+		}
 	}
 	p.cfg.Logger.Info("browser warm", "user", userID, "relaunched", existed)
 	return nil
@@ -142,8 +167,33 @@ func (p *Pool) StopUser(userID string) {
 	e, ok := p.sessions[userID]
 	delete(p.sessions, userID)
 	p.mu.Unlock()
-	if ok && e.session != nil {
-		e.session.Close()
+	if ok {
+		closeEntryTabs(e)
+		if e.session != nil {
+			e.session.Close()
+		}
+	}
+}
+
+// closeEntryTabs closes any warm tabs attached to the entry. Idempotent
+// per-tab (warmTab.closed guard). Called whenever a session is being torn
+// down or replaced — the new session can't reuse the old session's chromedp
+// contexts, so the tabs must die with the session.
+func closeEntryTabs(e *entry) {
+	if e == nil {
+		return
+	}
+	e.tabsMu.Lock()
+	tabs := e.tabs
+	e.tabs = nil
+	e.tabsMu.Unlock()
+	for _, wt := range tabs {
+		wt.mu.Lock()
+		if !wt.closed {
+			wt.closed = true
+			wt.tab.Close()
+		}
+		wt.mu.Unlock()
 	}
 }
 
@@ -152,6 +202,7 @@ func (p *Pool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for _, e := range p.sessions {
+		closeEntryTabs(e)
 		if e.session != nil {
 			e.session.Close()
 		}
@@ -163,9 +214,20 @@ func (p *Pool) Close() {
 // underlying Chrome has died (chromedp ctx cancelled), the session is
 // transparently relaunched and the booking proceeds on the fresh session.
 func (p *Pool) HoldCampsite(ctx context.Context, userID, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
+	ctx = WithLogger(ctx, p.cfg.Logger.With(
+		"correlation_id", newCorrelationID(),
+		"user_id", userID,
+		"campsite_id", campsiteID,
+		"campground_id", campgroundID,
+	))
 	res, err := p.holdOnce(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
 	if !errors.Is(err, ErrNotLoggedIn) {
 		observeHoldMetrics(res, err)
+		// Path is set by the caller wrapper if it knows; if not (direct
+		// HoldCampsite caller, no warm-tab context), tag as main_session.
+		if res != nil && res.Path == "" {
+			res.Path = HoldPathMainSession
+		}
 		return res, err
 	}
 	// Session JWT expired silently. Force a full relaunch (login) and try
@@ -177,6 +239,9 @@ func (p *Pool) HoldCampsite(ctx context.Context, userID, campsiteID, campgroundI
 	}
 	res, err = p.holdOnce(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
 	observeHoldMetrics(res, err)
+	if res != nil {
+		res.Path = HoldPathRelaunchRetry
+	}
 	return res, err
 }
 
@@ -221,9 +286,289 @@ func (p *Pool) holdOnce(ctx context.Context, userID, campsiteID, campgroundID st
 	if e.disabled {
 		return nil, errors.New("session disabled")
 	}
+	// If the tab is already prewarmed on this site, skip the Nav +
+	// RecaptchaWait phases and go straight to the booking script. The
+	// recaptcha token is consumed on success, but the grecaptcha binding
+	// stays loaded — leave prewarmedSite as-is so a follow-up hold on the
+	// same site still skips Nav. Clear it when the booked site differs (we
+	// definitely navigated) so the next call doesn't lie about state.
 	opCtx, cancel := sessionOperationContext(e.session.Ctx(), ctx)
 	defer cancel()
+	if e.prewarmedSite == campsiteID {
+		return HoldFast(opCtx, campsiteID, campgroundID, checkIn, checkOut)
+	}
+	e.prewarmedSite = campsiteID
 	return e.session.HoldCampsite(opCtx, campsiteID, campgroundID, checkIn, checkOut)
+}
+
+// EnsureWarmTabForRequest guarantees there is a dedicated Chrome tab open
+// for this (userID, requestID) tuple, navigated to campsiteID and with the
+// grecaptcha enterprise script loaded. Idempotent: re-navigates the
+// existing tab if campsiteID changes (e.g. the schniff's chosen candidate
+// rotated), no-ops if the tab is already on the right page.
+//
+// One-tab-per-schniff is intentional. The manager keeps the tabs alive
+// across poll cycles so HoldCampsiteFor pays only the script_eval cost
+// (~1.15s = recaptcha mint + rec.gov POST), not Nav or the recaptcha JS
+// load. Tab is closed via CloseRequestTab when the schniff is deactivated.
+func (p *Pool) EnsureWarmTabForRequest(ctx context.Context, userID string, requestID int64, campsiteID string) error {
+	ctx = WithLogger(ctx, p.cfg.Logger.With(
+		"correlation_id", newCorrelationID(),
+		"user_id", userID,
+		"request_id", requestID,
+		"campsite_id", campsiteID,
+		"op", "ensure_warm_tab",
+	))
+	e, err := p.ensureAlive(ctx, userID)
+	if err != nil {
+		return err
+	}
+	e.tabsMu.Lock()
+	if e.tabs == nil {
+		e.tabs = map[int64]*warmTab{}
+	}
+	wt, ok := e.tabs[requestID]
+	if !ok {
+		t, err := e.session.NewTab()
+		if err != nil {
+			e.tabsMu.Unlock()
+			return fmt.Errorf("open tab for request %d: %w", requestID, err)
+		}
+		wt = &warmTab{tab: t}
+		e.tabs[requestID] = wt
+	}
+	e.tabsMu.Unlock()
+
+	wt.mu.Lock()
+	defer wt.mu.Unlock()
+	if wt.closed {
+		return errors.New("warm tab closed")
+	}
+	if wt.site == campsiteID {
+		return nil
+	}
+	// Bound the prewarm so a stuck nav can't block the background loop
+	// forever. 60s matches the chromedp Poll budget inside PrewarmCampsite.
+	pctx, pcancel := context.WithTimeout(wt.tab.Ctx(), 60*time.Second)
+	defer pcancel()
+	opCtx, opcancel := sessionOperationContext(pctx, ctx)
+	defer opcancel()
+	if _, err := PrewarmCampsite(opCtx, campsiteID); err != nil {
+		return fmt.Errorf("prewarm tab: %w", err)
+	}
+	wt.site = campsiteID
+	return nil
+}
+
+// HoldOnRequestTab performs a hold using the warm tab dedicated to
+// requestID. If the warm tab matches campsiteID, runs HoldFast (skips Nav
+// + recaptcha wait, ~1.15s on prod). If campsiteID differs (rare: schniff
+// chose a different candidate than the tab is currently on), navigates the
+// tab to the new site first. If there is no warm tab for this request,
+// falls back to the main session's HoldCampsite path.
+//
+// Returns ErrNotLoggedIn the same way HoldCampsite does — caller (or the
+// retry layer) is responsible for re-login + retry.
+func (p *Pool) HoldOnRequestTab(ctx context.Context, userID string, requestID int64, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
+	ctx = WithLogger(ctx, p.cfg.Logger.With(
+		"correlation_id", newCorrelationID(),
+		"user_id", userID,
+		"request_id", requestID,
+		"campsite_id", campsiteID,
+		"campground_id", campgroundID,
+		"op", "hold_on_request_tab",
+	))
+	e, err := p.ensureAlive(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	e.tabsMu.Lock()
+	wt := e.tabs[requestID]
+	e.tabsMu.Unlock()
+	if wt == nil {
+		// No dedicated tab — fall back to the main tab.
+		p.cfg.Logger.Warn("no warm tab; falling back to main session",
+			"user_id", userID, "request_id", requestID, "campsite_id", campsiteID)
+		res, err := p.HoldCampsite(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
+		tagPath(res, HoldPathMainSession)
+		p.logHoldPath(HoldPathMainSession, userID, requestID, campsiteID, res, err)
+		return res, err
+	}
+	res, path, err := p.holdOnRequestTabOnce(ctx, e, wt, campsiteID, campgroundID, checkIn, checkOut, requestID, userID)
+	if !errors.Is(err, ErrNotLoggedIn) {
+		tagPath(res, path)
+		p.logHoldPath(path, userID, requestID, campsiteID, res, err)
+		return res, err
+	}
+	// The warm tab's JWT silently expired. The whole session is stale —
+	// any other warm tab in this entry has the same problem. Force a full
+	// relaunch + login (this also closes all warm tabs via closeEntryTabs
+	// inside launchUser). The reconcile loop will rebuild the warm tabs
+	// on its next tick; for THIS booking we fall back to a fresh
+	// HoldCampsite on the new session so the user doesn't miss this race.
+	p.cfg.Logger.Warn("warm-tab hold: session not logged in; relaunching and retrying",
+		"user_id", userID, "request_id", requestID, "campsite_id", campsiteID)
+	metrics.BookerRelaunchTotal.WithLabelValues("warm_tab_session_expired").Inc()
+	if relaunchErr := p.launchUser(ctx, userID); relaunchErr != nil {
+		return nil, fmt.Errorf("relaunch after warm-tab session expiry: %w", relaunchErr)
+	}
+	res, err = p.holdOnce(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
+	tagPath(res, HoldPathRelaunchRetry)
+	observeHoldMetrics(res, err)
+	p.logHoldPath(HoldPathRelaunchRetry, userID, requestID, campsiteID, res, err)
+	return res, err
+}
+
+// tagPath stamps the path onto the result if non-nil. Tolerates nil so
+// callers don't have to guard every branch.
+func tagPath(res *HoldResult, path HoldPath) {
+	if res == nil {
+		return
+	}
+	res.Path = path
+}
+
+// logHoldPath emits the single high-signal line summarising which Pool
+// branch produced this hold. Separate from the per-phase booking_phase
+// stream — operators grep this to find the path-choice decision.
+func (p *Pool) logHoldPath(path HoldPath, userID string, requestID int64, campsiteID string, res *HoldResult, err error) {
+	wall := time.Duration(0)
+	orderID := ""
+	if res != nil {
+		wall = res.Timings.Total
+		orderID = res.OrderID
+	}
+	attrs := []any{
+		slog.String("path", string(path)),
+		slog.String("user_id", userID),
+		slog.Int64("request_id", requestID),
+		slog.String("campsite_id", campsiteID),
+		slog.Duration("wall", wall),
+		slog.String("order_id", orderID),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("err", err.Error()))
+		p.cfg.Logger.Warn("auto_book_path", attrs...)
+		return
+	}
+	p.cfg.Logger.Info("auto_book_path", attrs...)
+}
+
+// holdOnRequestTabOnce returns the hold result + which warm-tab subpath
+// produced it (fast vs nav). The outer HoldOnRequestTab uses the subpath
+// label to tag the HoldResult; on ErrNotLoggedIn it discards the label
+// and re-runs as a relaunch_retry.
+func (p *Pool) holdOnRequestTabOnce(ctx context.Context, e *entry, wt *warmTab, campsiteID, campgroundID string, checkIn, checkOut time.Time, requestID int64, userID string) (*HoldResult, HoldPath, error) {
+	wt.mu.Lock()
+	defer wt.mu.Unlock()
+	if wt.closed {
+		return nil, HoldPathMainSession, errors.New("warm tab closed")
+	}
+	opCtx, cancel := sessionOperationContext(wt.tab.Ctx(), ctx)
+	defer cancel()
+	if wt.site != campsiteID {
+		// Different candidate this time. Pay the Nav cost on this tab and
+		// fall through to the full HoldCampsite. Same warm Chrome window
+		// with the SPA already loaded — typically faster than a cold
+		// session, but still slower than the fast path.
+		p.cfg.Logger.Info("warm tab campsite mismatch; navigating",
+			"user_id", userID, "request_id", requestID,
+			"from", wt.site, "to", campsiteID)
+		res, err := e.session.HoldCampsite(opCtx, campsiteID, campgroundID, checkIn, checkOut)
+		if err == nil && res != nil {
+			wt.site = campsiteID
+		}
+		observeHoldMetrics(res, err)
+		return res, HoldPathWarmTabNav, err
+	}
+	// Fast path: tab is already on the right page.
+	res, err := HoldFast(opCtx, campsiteID, campgroundID, checkIn, checkOut)
+	observeHoldMetrics(res, err)
+	return res, HoldPathWarmTabFast, err
+}
+
+// CloseRequestTab closes the dedicated warm tab for (userID, requestID).
+// Called by the manager when a schniff request is deactivated. Safe to
+// call multiple times.
+func (p *Pool) CloseRequestTab(userID string, requestID int64) {
+	p.mu.RLock()
+	e, ok := p.sessions[userID]
+	p.mu.RUnlock()
+	if !ok {
+		return
+	}
+	e.tabsMu.Lock()
+	wt, ok := e.tabs[requestID]
+	if ok {
+		delete(e.tabs, requestID)
+	}
+	e.tabsMu.Unlock()
+	if !ok {
+		return
+	}
+	wt.mu.Lock()
+	if !wt.closed {
+		wt.closed = true
+		wt.tab.Close()
+	}
+	wt.mu.Unlock()
+}
+
+// ListRequestTabs returns the requestIDs currently holding a warm tab for
+// userID. Used by the manager's reconcile loop to figure out which tabs
+// to close (active schniff set is the source of truth).
+func (p *Pool) ListRequestTabs(userID string) []int64 {
+	p.mu.RLock()
+	e, ok := p.sessions[userID]
+	p.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	e.tabsMu.Lock()
+	defer e.tabsMu.Unlock()
+	out := make([]int64, 0, len(e.tabs))
+	for id := range e.tabs {
+		out = append(out, id)
+	}
+	return out
+}
+
+// PrewarmFor navigates the user's hot tab to /camping/campsites/{campsiteID}
+// and waits for grecaptcha.enterprise.execute to be callable, so a follow-up
+// HoldCampsite call on the same (user, site) skips Nav + RecaptchaWait
+// (~1.1s on prod). Idempotent: if the tab is already on this site, returns
+// immediately. Safe to fire-and-forget — errors are logged and the next
+// HoldCampsite will fall back to the full nav path.
+//
+// Serialized per-user via e.mu, same lock as HoldCampsite, so a prewarm in
+// progress will not race a concurrent hold.
+func (p *Pool) PrewarmFor(ctx context.Context, userID, campsiteID string) error {
+	ctx = WithLogger(ctx, p.cfg.Logger.With(
+		"correlation_id", newCorrelationID(),
+		"user_id", userID,
+		"campsite_id", campsiteID,
+		"op", "prewarm",
+	))
+	e, err := p.ensureAlive(ctx, userID)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.disabled {
+		return errors.New("session disabled")
+	}
+	if e.prewarmedSite == campsiteID {
+		return nil
+	}
+	opCtx, cancel := sessionOperationContext(e.session.Ctx(), ctx)
+	defer cancel()
+	if _, err := PrewarmCampsite(opCtx, campsiteID); err != nil {
+		// Don't latch prewarmedSite on failure — next call retries.
+		return err
+	}
+	e.prewarmedSite = campsiteID
+	return nil
 }
 
 // ensureAlive returns a live entry for userID. If the current entry's
@@ -300,6 +645,8 @@ func (p *Pool) refreshAll(ctx context.Context) {
 		if err := e.session.Refresh(rctx); err != nil {
 			p.cfg.Logger.Warn("session refresh failed", "user", id, "err", err)
 		}
+		// Refresh navigates to the homepage — any prewarm is stale now.
+		e.prewarmedSite = ""
 		cancel()
 		timeoutCancel()
 		e.mu.Unlock()

--- a/internal/booker/pool.go
+++ b/internal/booker/pool.go
@@ -61,15 +61,19 @@ type entry struct {
 	tabs   map[int64]*warmTab // keyed by schniff_request.id
 }
 
-// warmTab is a dedicated Chrome tab pre-navigated to a specific campsite
-// page for one active schniff request. The tab stays alive for the
-// schniff's lifetime so HoldCampsite on this tab pays no Nav or recaptcha
-// load cost — just session_check + script_eval.
+// warmTab is a dedicated Chrome tab pre-navigated to the schniff's
+// campground overview page (/camping/campgrounds/{id}) for one active
+// schniff request. The tab stays alive for the schniff's lifetime.
+// Empirically verified: a hold POST minted from the campground page is
+// accepted by rec.gov (STATUS=200) for any campsite in that campground —
+// the booking POST URL is keyed by campgroundID and the recaptcha token
+// is action-bound, not URL-bound. So one tab serves every candidate
+// campsite in the schniff's campground without ever re-navigating.
 type warmTab struct {
-	mu     sync.Mutex // serializes Prewarm + Hold on this tab
-	tab    *Tab
-	site   string // last campsite the tab was navigated to
-	closed bool
+	mu         sync.Mutex // serializes Prewarm + Hold on this tab
+	tab        *Tab
+	campground string // last campground the tab was navigated to ("" until first Prewarm)
+	closed     bool
 }
 
 func NewPool(cfg PoolConfig) *Pool {
@@ -302,21 +306,22 @@ func (p *Pool) holdOnce(ctx context.Context, userID, campsiteID, campgroundID st
 }
 
 // EnsureWarmTabForRequest guarantees there is a dedicated Chrome tab open
-// for this (userID, requestID) tuple, navigated to campsiteID and with the
-// grecaptcha enterprise script loaded. Idempotent: re-navigates the
-// existing tab if campsiteID changes (e.g. the schniff's chosen candidate
-// rotated), no-ops if the tab is already on the right page.
+// for this (userID, requestID) tuple, parked on the schniff's campground
+// overview page (/camping/campgrounds/{campgroundID}) with grecaptcha
+// loaded. From that tab a follow-up HoldOnRequestTab can book *any*
+// campsite in the campground via HoldFast (no re-navigation needed).
+// Idempotent: no-ops if the tab is already on this campground.
 //
 // One-tab-per-schniff is intentional. The manager keeps the tabs alive
-// across poll cycles so HoldCampsiteFor pays only the script_eval cost
-// (~1.15s = recaptcha mint + rec.gov POST), not Nav or the recaptcha JS
-// load. Tab is closed via CloseRequestTab when the schniff is deactivated.
-func (p *Pool) EnsureWarmTabForRequest(ctx context.Context, userID string, requestID int64, campsiteID string) error {
+// across poll cycles so HoldOnRequestTab pays only the script_eval cost
+// (~1.15s = recaptcha mint + rec.gov POST). Tab is closed via
+// CloseRequestTab when the schniff is deactivated.
+func (p *Pool) EnsureWarmTabForRequest(ctx context.Context, userID string, requestID int64, campgroundID string) error {
 	ctx = WithLogger(ctx, p.cfg.Logger.With(
 		"correlation_id", newCorrelationID(),
 		"user_id", userID,
 		"request_id", requestID,
-		"campsite_id", campsiteID,
+		"campground_id", campgroundID,
 		"op", "ensure_warm_tab",
 	))
 	e, err := p.ensureAlive(ctx, userID)
@@ -344,19 +349,19 @@ func (p *Pool) EnsureWarmTabForRequest(ctx context.Context, userID string, reque
 	if wt.closed {
 		return errors.New("warm tab closed")
 	}
-	if wt.site == campsiteID {
+	if wt.campground == campgroundID {
 		return nil
 	}
 	// Bound the prewarm so a stuck nav can't block the background loop
-	// forever. 60s matches the chromedp Poll budget inside PrewarmCampsite.
+	// forever. 60s matches the chromedp Poll budget inside PrewarmCampground.
 	pctx, pcancel := context.WithTimeout(wt.tab.Ctx(), 60*time.Second)
 	defer pcancel()
 	opCtx, opcancel := sessionOperationContext(pctx, ctx)
 	defer opcancel()
-	if _, err := PrewarmCampsite(opCtx, campsiteID); err != nil {
+	if _, err := PrewarmCampground(opCtx, campgroundID); err != nil {
 		return fmt.Errorf("prewarm tab: %w", err)
 	}
-	wt.site = campsiteID
+	wt.campground = campgroundID
 	return nil
 }
 
@@ -454,34 +459,33 @@ func (p *Pool) logHoldPath(path HoldPath, userID string, requestID int64, campsi
 	p.cfg.Logger.Info("auto_book_path", attrs...)
 }
 
-// holdOnRequestTabOnce returns the hold result + which warm-tab subpath
-// produced it (fast vs nav). The outer HoldOnRequestTab uses the subpath
-// label to tag the HoldResult; on ErrNotLoggedIn it discards the label
-// and re-runs as a relaunch_retry.
+// holdOnRequestTabOnce runs HoldFast on the schniff's warm tab. Because
+// the tab is parked on the campground overview page (not a specific
+// campsite), any campsite_id in this campground works without a
+// re-navigation. The mismatched-campsite branch from earlier iterations
+// is gone; there is no scenario where this tab needs to navigate during
+// a hold.
+//
+// If the warm tab's campground doesn't match the requested one (would
+// happen only if a schniff was migrated between campgrounds, which is
+// not currently supported), we fall back to the main-session
+// HoldCampsite path rather than navigating the warm tab — keeping this
+// function on the strict fast path.
 func (p *Pool) holdOnRequestTabOnce(ctx context.Context, e *entry, wt *warmTab, campsiteID, campgroundID string, checkIn, checkOut time.Time, requestID int64, userID string) (*HoldResult, HoldPath, error) {
 	wt.mu.Lock()
 	defer wt.mu.Unlock()
 	if wt.closed {
 		return nil, HoldPathMainSession, errors.New("warm tab closed")
 	}
+	if wt.campground != "" && wt.campground != campgroundID {
+		p.cfg.Logger.Warn("warm tab campground mismatch; falling back to main session",
+			"user_id", userID, "request_id", requestID,
+			"tab_campground", wt.campground, "wanted_campground", campgroundID)
+		res, err := p.HoldCampsite(ctx, userID, campsiteID, campgroundID, checkIn, checkOut)
+		return res, HoldPathMainSession, err
+	}
 	opCtx, cancel := sessionOperationContext(wt.tab.Ctx(), ctx)
 	defer cancel()
-	if wt.site != campsiteID {
-		// Different candidate this time. Pay the Nav cost on this tab and
-		// fall through to the full HoldCampsite. Same warm Chrome window
-		// with the SPA already loaded — typically faster than a cold
-		// session, but still slower than the fast path.
-		p.cfg.Logger.Info("warm tab campsite mismatch; navigating",
-			"user_id", userID, "request_id", requestID,
-			"from", wt.site, "to", campsiteID)
-		res, err := e.session.HoldCampsite(opCtx, campsiteID, campgroundID, checkIn, checkOut)
-		if err == nil && res != nil {
-			wt.site = campsiteID
-		}
-		observeHoldMetrics(res, err)
-		return res, HoldPathWarmTabNav, err
-	}
-	// Fast path: tab is already on the right page.
 	res, err := HoldFast(opCtx, campsiteID, campgroundID, checkIn, checkOut)
 	observeHoldMetrics(res, err)
 	return res, HoldPathWarmTabFast, err

--- a/internal/booker/prewarm.go
+++ b/internal/booker/prewarm.go
@@ -62,12 +62,52 @@ func logPhase(ctx context.Context, phase string, started time.Time, d time.Durat
 	lg.Info("booking_phase", attrs...)
 }
 
-// PrewarmCampsite navigates to the campsite page and waits until
-// grecaptcha.enterprise.execute is callable. After this returns, a follow-up
-// HoldFast on the same chromedp ctx skips Nav + RecaptchaWait entirely.
+// PrewarmCampground navigates to the campground overview page and waits
+// until grecaptcha.enterprise.execute is callable. After this returns, a
+// follow-up HoldFast on this tab can book *any* campsite in this
+// campground — the booking POST URL is keyed by campgroundID, and the
+// recaptcha token is bound to the action ("campsiteListBooking") not the
+// URL. Verified empirically: hold POSTs from /camping/campgrounds/{id}
+// succeed against rec.gov with STATUS=200 + order_id.
+//
+// This is the parking strategy for per-schniff warm tabs: one tab per
+// schniff, parked on its campground page once, never re-navigated. When
+// arbitration picks any campsite in that campground we HoldFast on the
+// same tab.
 //
 // Safe to call repeatedly; if the tab is already on the right page and
 // recaptcha is loaded, the second call only re-checks the readiness probe.
+func PrewarmCampground(ctx context.Context, campgroundID string) (PrewarmTimings, error) {
+	var t PrewarmTimings
+	navStart := time.Now()
+	navErr := chromedp.Run(ctx,
+		chromedp.Navigate(fmt.Sprintf("%s/camping/campgrounds/%s", SiteOrigin, campgroundID)),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	)
+	t.Nav = time.Since(navStart)
+	logPhase(ctx, "prewarm_nav", navStart, t.Nav, navErr)
+	if navErr != nil {
+		return t, fmt.Errorf("nav: %w", navErr)
+	}
+
+	recStart := time.Now()
+	recErr := chromedp.Run(ctx, chromedp.Poll(
+		`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
+		nil, chromedp.WithPollingTimeout(30*time.Second),
+	))
+	t.RecaptchaWait = time.Since(recStart)
+	logPhase(ctx, "prewarm_recaptcha_wait", recStart, t.RecaptchaWait, recErr)
+	if recErr != nil {
+		return t, fmt.Errorf("wait recaptcha: %w", recErr)
+	}
+	return t, nil
+}
+
+// PrewarmCampsite is retained for callers (cmd/booker-bench) that want to
+// park on a specific campsite page. New code should prefer
+// PrewarmCampground — booking POSTs work the same from either page, and
+// the campground page lets one tab serve every campsite in the campground
+// without re-navigating.
 func PrewarmCampsite(ctx context.Context, campsiteID string) (PrewarmTimings, error) {
 	var t PrewarmTimings
 	navStart := time.Now()

--- a/internal/booker/prewarm.go
+++ b/internal/booker/prewarm.go
@@ -1,0 +1,240 @@
+package booker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+// loggerKey carries a slog.Logger pre-bound with booking-correlation fields
+// (correlation_id, user_id, campsite_id, request_id, etc) so internal
+// phase-completion lines emit those attributes without each helper re-deriving
+// them. Callers attach via WithLogger; absent context returns slog.Default().
+type loggerKey struct{}
+
+// WithLogger returns a copy of ctx carrying lg as the booking phase logger.
+// Each phase emits a single "booking_phase" log line at completion with
+// phase + duration, plus whatever fields lg already has bound.
+func WithLogger(ctx context.Context, lg *slog.Logger) context.Context {
+	if lg == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, loggerKey{}, lg)
+}
+
+// newCorrelationID returns a short opaque token suitable for correlating
+// every phase line emitted during a single booking. Not security-sensitive;
+// short on purpose so grep'd logs stay readable.
+func newCorrelationID() string {
+	return fmt.Sprintf("bkg-%d", time.Now().UnixNano()%1_000_000_000)
+}
+
+func loggerFrom(ctx context.Context) *slog.Logger {
+	if v := ctx.Value(loggerKey{}); v != nil {
+		if lg, ok := v.(*slog.Logger); ok {
+			return lg
+		}
+	}
+	return slog.Default()
+}
+
+// logPhase emits the standard booking-phase line. Called at the end of every
+// timed section so an operator can reconstruct the exact wall-clock ordering
+// of a single booking from grep'd logs.
+func logPhase(ctx context.Context, phase string, started time.Time, d time.Duration, err error) {
+	lg := loggerFrom(ctx)
+	attrs := []any{
+		slog.String("phase", phase),
+		slog.Time("started_at", started),
+		slog.Duration("duration", d),
+	}
+	if err != nil {
+		attrs = append(attrs, slog.String("err", err.Error()))
+		lg.Warn("booking_phase", attrs...)
+		return
+	}
+	lg.Info("booking_phase", attrs...)
+}
+
+// PrewarmCampsite navigates to the campsite page and waits until
+// grecaptcha.enterprise.execute is callable. After this returns, a follow-up
+// HoldFast on the same chromedp ctx skips Nav + RecaptchaWait entirely.
+//
+// Safe to call repeatedly; if the tab is already on the right page and
+// recaptcha is loaded, the second call only re-checks the readiness probe.
+func PrewarmCampsite(ctx context.Context, campsiteID string) (PrewarmTimings, error) {
+	var t PrewarmTimings
+	navStart := time.Now()
+	navErr := chromedp.Run(ctx,
+		chromedp.Navigate(fmt.Sprintf("%s/camping/campsites/%s", SiteOrigin, campsiteID)),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	)
+	t.Nav = time.Since(navStart)
+	logPhase(ctx, "prewarm_nav", navStart, t.Nav, navErr)
+	if navErr != nil {
+		return t, fmt.Errorf("nav: %w", navErr)
+	}
+
+	recStart := time.Now()
+	recErr := chromedp.Run(ctx, chromedp.Poll(
+		`typeof grecaptcha !== 'undefined' && grecaptcha.enterprise && typeof grecaptcha.enterprise.execute === 'function'`,
+		nil, chromedp.WithPollingTimeout(30*time.Second),
+	))
+	t.RecaptchaWait = time.Since(recStart)
+	logPhase(ctx, "prewarm_recaptcha_wait", recStart, t.RecaptchaWait, recErr)
+	if recErr != nil {
+		return t, fmt.Errorf("wait recaptcha: %w", recErr)
+	}
+	return t, nil
+}
+
+// PrewarmTimings carries latency for the pre-payable portion of a hold.
+type PrewarmTimings struct {
+	Nav           time.Duration
+	RecaptchaWait time.Duration
+}
+
+// HoldFast performs only the booking-critical portion: session check + the
+// recaptcha mint + POST script. It does NOT navigate — caller must have
+// already loaded a page where grecaptcha.enterprise is initialized
+// (typically via PrewarmCampsite).
+func HoldFast(ctx context.Context, campsiteID, campgroundID string, checkIn, checkOut time.Time) (*HoldResult, error) {
+	const iso = "2006-01-02T00:00:00.000Z"
+	if !checkIn.Before(checkOut) {
+		return nil, errors.New("check-in must be before check-out")
+	}
+	t := &HoldTimings{}
+	totalStart := time.Now()
+	// finalize captures the final wall time on every return path so
+	// res.Timings.Total is meaningful (and the matching phase log fires).
+	// Caller-visible HoldResult.Timings is a value copy of *t at the moment
+	// of return, so we must set Total BEFORE constructing the result.
+	finalize := func() {
+		t.Total = time.Since(totalStart)
+		logPhase(ctx, "hold_fast_total", totalStart, t.Total, nil)
+	}
+
+	sessionStart := time.Now()
+	var hasAccount bool
+	sErr := chromedp.Run(ctx, chromedp.Evaluate(
+		`!!(window.localStorage.getItem('recaccount'))`, &hasAccount,
+	))
+	t.SessionCheck = time.Since(sessionStart)
+	logPhase(ctx, "session_check", sessionStart, t.SessionCheck, sErr)
+	if sErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("check session: %w", sErr)
+	}
+	if !hasAccount {
+		finalize()
+		return &HoldResult{Timings: *t}, ErrNotLoggedIn
+	}
+
+	nightMap := map[string]map[string]string{}
+	for day := checkIn; day.Before(checkOut); day = day.AddDate(0, 0, 1) {
+		nightMap[day.UTC().Format(iso)] = map[string]string{
+			"campsite_id": campsiteID, "campsite_loop": "", "campsite_name": "",
+		}
+	}
+	payload := map[string]any{
+		"campsiteID":   campsiteID,
+		"campgroundID": campgroundID,
+		"checkIn":      checkIn.UTC().Format(iso),
+		"checkOut":     checkOut.UTC().Format(iso),
+		"nightMap":     nightMap,
+		"siteKey":      RecaptchaSiteKey,
+		"action":       RecaptchaAction,
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	script := `(async (p) => {
+		const _t0 = performance.now();
+		const token = await grecaptcha.enterprise.execute(p.siteKey, {action: p.action});
+		const _tokenMs = performance.now() - _t0;
+		const recRaw = window.localStorage.getItem('recaccount');
+		if (!recRaw) throw new Error('no recaccount in localStorage');
+		const rec = JSON.parse(recRaw);
+		const accessToken = rec.access_token;
+		const accountID = rec.account && rec.account.account_id;
+		if (!accessToken || !accountID) throw new Error('missing access_token or account_id in recaccount');
+		const body = {
+			reservations: [{
+				account_id: accountID,
+				campsite_id: p.campsiteID,
+				check_in: p.checkIn,
+				check_out: p.checkOut,
+				reservation_options: {
+					night_map: p.nightMap,
+					recommendation_referrer: 'campground-vnull:campsitePage',
+				},
+			}],
+			gate_a: {value: token, description: p.action, success: true, terminal: 'east'},
+		};
+		const _postStart = performance.now();
+		const response = await fetch('/api/camps/reservations/campgrounds/' + p.campgroundID + '/multi', {
+			method: 'POST',
+			headers: {'content-type': 'application/json', 'authorization': 'Bearer ' + accessToken},
+			body: JSON.stringify(body),
+			credentials: 'include',
+		});
+		const text = await response.text();
+		const _postMs = performance.now() - _postStart;
+		let parsed;
+		try { parsed = JSON.parse(text); } catch (_) { parsed = {raw: text}; }
+		return {status: response.status, _recaptcha_token_ms: _tokenMs, _recgov_post_ms: _postMs, ...parsed};
+	})(` + string(payloadJSON) + `)`
+
+	var out map[string]any
+	awaitOpt := func(p *runtime.EvaluateParams) *runtime.EvaluateParams { return p.WithAwaitPromise(true) }
+	scriptStart := time.Now()
+	scriptErr := chromedp.Run(ctx, chromedp.Evaluate(script, &out, awaitOpt))
+	t.ScriptEval = time.Since(scriptStart)
+	logPhase(ctx, "script_eval", scriptStart, t.ScriptEval, scriptErr)
+	if scriptErr != nil {
+		finalize()
+		return &HoldResult{Timings: *t}, fmt.Errorf("exec booking: %w", scriptErr)
+	}
+	t.RecaptchaToken = readMillis(out, "_recaptcha_token_ms")
+	t.RecGovPost = readMillis(out, "_recgov_post_ms")
+	// The in-page perf markers are the source of truth for the script's
+	// internal breakdown; emit them as phase lines so they appear in the
+	// same correlated stream as everything else.
+	if t.RecaptchaToken > 0 {
+		logPhase(ctx, "recaptcha_token_mint", scriptStart, t.RecaptchaToken, nil)
+	}
+	if t.RecGovPost > 0 {
+		logPhase(ctx, "recgov_post", scriptStart.Add(t.RecaptchaToken), t.RecGovPost, nil)
+	}
+	finalize()
+	result := &HoldResult{OrderID: ExtractOrderID(out), Raw: out, Timings: *t}
+	if err := bookingResponseError(out, result.OrderID); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// Tab represents an additional Chrome tab in an existing Session. Each tab
+// has its own page/target so multiple tabs can be parked on different
+// campsite pages and fired independently.
+type Tab struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewTab opens a new tab in the session's Chrome instance.
+func (s *Session) NewTab() (*Tab, error) {
+	ctx, cancel := chromedp.NewContext(s.ctx)
+	if err := chromedp.Run(ctx); err != nil {
+		cancel()
+		return nil, fmt.Errorf("open tab: %w", err)
+	}
+	return &Tab{ctx: ctx, cancel: cancel}, nil
+}
+
+func (t *Tab) Ctx() context.Context { return t.ctx }
+func (t *Tab) Close()                { t.cancel() }

--- a/internal/booker/prewarm.go
+++ b/internal/booker/prewarm.go
@@ -277,4 +277,4 @@ func (s *Session) NewTab() (*Tab, error) {
 }
 
 func (t *Tab) Ctx() context.Context { return t.ctx }
-func (t *Tab) Close()                { t.cancel() }
+func (t *Tab) Close()               { t.cancel() }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2014,29 +2014,6 @@ func (s *Store) GetCampsiteDetails(ctx context.Context, provider, campgroundID, 
 	return details, nil
 }
 
-// PickParkingCampsite returns a stable campsite_id for the given campground
-// that the booker pool can park a warm tab on. Highest rating first,
-// alphabetical tie-break (so the choice is deterministic across calls and
-// the warm tab doesn't churn). Returns "" if no campsite metadata exists
-// for that campground yet.
-func (s *Store) PickParkingCampsite(ctx context.Context, provider, campgroundID string) (string, error) {
-	row := s.DB.QueryRowContext(ctx, `
-		SELECT campsite_id
-		FROM campsite_metadata
-		WHERE provider=? AND campground_id=?
-		ORDER BY rating DESC, campsite_id ASC
-		LIMIT 1
-	`, provider, campgroundID)
-	var id string
-	if err := row.Scan(&id); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return "", nil
-		}
-		return "", fmt.Errorf("pick parking campsite: %w", err)
-	}
-	return id, nil
-}
-
 // GetCampsiteDetailsBatch retrieves detailed information for multiple campsites efficiently
 func (s *Store) GetCampsiteDetailsBatch(ctx context.Context, provider, campgroundID string, campsiteIDs []string) (map[string]CampsiteDetails, error) {
 	if len(campsiteIDs) == 0 {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2014,6 +2014,29 @@ func (s *Store) GetCampsiteDetails(ctx context.Context, provider, campgroundID, 
 	return details, nil
 }
 
+// PickParkingCampsite returns a stable campsite_id for the given campground
+// that the booker pool can park a warm tab on. Highest rating first,
+// alphabetical tie-break (so the choice is deterministic across calls and
+// the warm tab doesn't churn). Returns "" if no campsite metadata exists
+// for that campground yet.
+func (s *Store) PickParkingCampsite(ctx context.Context, provider, campgroundID string) (string, error) {
+	row := s.DB.QueryRowContext(ctx, `
+		SELECT campsite_id
+		FROM campsite_metadata
+		WHERE provider=? AND campground_id=?
+		ORDER BY rating DESC, campsite_id ASC
+		LIMIT 1
+	`, provider, campgroundID)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("pick parking campsite: %w", err)
+	}
+	return id, nil
+}
+
 // GetCampsiteDetailsBatch retrieves detailed information for multiple campsites efficiently
 func (s *Store) GetCampsiteDetailsBatch(ctx context.Context, provider, campgroundID string, campsiteIDs []string) (map[string]CampsiteDetails, error) {
 	if len(campsiteIDs) == 0 {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -92,6 +92,13 @@ func (m *Manager) Run(ctx context.Context) {
 	// Expire deactivation runs on its own cadence (used to run every poll cycle).
 	go m.runExpiryReaper(ctx)
 
+	// Warm-tab reconcile loop: keep one Chrome tab open per active
+	// auto-book schniff, parked on a recaptcha-loaded campsite page so
+	// hold POSTs skip the ~1.1s Nav + recaptcha load.
+	if m.pool != nil {
+		go m.runWarmTabReconciler(ctx)
+	}
+
 	// Start a goroutine for each provider
 	for _, providerName := range m.reg.GetProviderNames() {
 		go m.runProviderLoop(ctx, providerName)

--- a/internal/manager/notifications.go
+++ b/internal/manager/notifications.go
@@ -267,6 +267,15 @@ func (m *Manager) processCampgroundBucket(
 			continue
 		}
 
+		// CRITICAL PATH: fire the booking goroutine first, before any
+		// Discord work. UserChannelCreate + embed send adds ~500ms-1s of
+		// blocking time that the booking shouldn't wait on — every ms
+		// matters when racing competitor bots to the same site.
+		if r.Won && m.pool != nil && m.pool.HasUser(p.req.UserID) {
+			expectedBooks++
+			go m.attemptHoldAndReport(ctx, p.req, r.Pick, batchID, outcomeChan)
+		}
+
 		channel, cerr := m.notifier.UserChannelCreate(p.req.UserID)
 		if cerr != nil {
 			m.logger.Warn("user channel create failed",
@@ -323,17 +332,11 @@ func (m *Manager) processCampgroundBucket(
 			}
 		}
 
-		// Auto-book + channel ping only when the user actually won a site in
-		// arbitration. An ExpiringOwner who didn't also win something else
-		// skips both. Channel is suppressed when the won site is one we
-		// recently held (i.e. the "new" availability is a cycle, not news).
+		// Channel broadcast (silly public message) — only for winners on
+		// truly new sites (not cycle-back from an expired hold).
 		if r.Won {
 			if _, recyc := recentHeldSet[r.Pick.CampsiteID]; !recyc {
 				m.maybeChannelBroadcast(p.req.UserID)
-			}
-			if m.pool != nil && m.pool.HasUser(p.req.UserID) {
-				expectedBooks++
-				go m.attemptHoldAndReport(ctx, p.req, r.Pick, batchID, channel.ID, outcomeChan)
 			}
 		}
 	}
@@ -423,16 +426,15 @@ func (m *Manager) maybeChannelBroadcast(userID string) {
 }
 
 // attemptHoldAndReport runs one HoldCampsite call synchronously and reports
-// the result back to the bucket coordinator via outcomeChan. It also sends
-// the user-facing "attempting" + result DMs directly to channelID, and
-// records the booking row to the DB — same side effects as the old
-// startBookingAttempt, just structured to return its outcome upward.
+// the result back to the bucket coordinator via outcomeChan. The booking POST
+// is the hot path — every step before m.pool.HoldCampsite is shoved off the
+// critical path: the "attempting" DM goes in a goroutine, and the user-DM
+// channel is resolved concurrently with the chromedp call.
 func (m *Manager) attemptHoldAndReport(
 	ctx context.Context,
 	req db.SchniffRequest,
 	pick booker.Pick,
 	batchID string,
-	channelID string,
 	outcomeChan chan<- bookOutcome,
 ) {
 	m.logger.Info("auto-booking attempt",
@@ -447,21 +449,37 @@ func (m *Manager) attemptHoldAndReport(
 		slog.String("batch_id", batchID),
 	)
 
+	// Resolve the DM channel concurrently with the booking POST. Discord
+	// caches DMs so this is usually instant, but we don't want the chromedp
+	// nav waiting on it — only the result-send needs the channel.
+	channelCh := make(chan string, 1)
 	go func() {
+		channel, err := m.notifier.UserChannelCreate(req.UserID)
+		if err != nil {
+			m.logger.Warn("auto-book: user channel create failed", slog.String("userID", req.UserID), slog.Any("err", err))
+			channelCh <- ""
+			return
+		}
+		channelCh <- channel.ID
 		msg := fmt.Sprintf("🛒 I'm attempting to hold site **%s** for you right now (%s → %s, %d night%s). I'll let you know how I go.",
 			pick.CampsiteID,
 			pick.CheckIn.Format("Mon Jan 2"),
 			pick.CheckOut.Format("Mon Jan 2"),
 			pick.Nights, pluralS(pick.Nights),
 		)
-		if _, err := m.notifier.ChannelMessageSend(channelID, msg); err != nil {
+		if _, err := m.notifier.ChannelMessageSend(channel.ID, msg); err != nil {
 			m.logger.Warn("send attempting message failed", slog.Any("err", err))
 		}
 	}()
 
 	bctx, bcancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer bcancel()
-	res, err := m.pool.HoldCampsite(bctx, req.UserID, pick.CampsiteID, req.CampgroundID, pick.CheckIn, pick.CheckOut)
+	// HoldOnRequestTab uses the warm tab dedicated to this schniff
+	// (parked + recaptcha-loaded by the reconcile loop). If the tab is on
+	// the right campsite, this runs HoldFast (~1.15s on prod); if it's on
+	// a different campsite or no tab exists yet, it falls back to the
+	// equivalent of the old HoldCampsite path so the booking still fires.
+	res, err := m.pool.HoldOnRequestTab(bctx, req.UserID, req.ID, pick.CampsiteID, req.CampgroundID, pick.CheckIn, pick.CheckOut)
 
 	booking := db.Booking{
 		BatchID:      batchID,
@@ -489,10 +507,19 @@ func (m *Manager) attemptHoldAndReport(
 	}
 	recCancel()
 
+	path := ""
+	wall := time.Duration(0)
+	if res != nil {
+		path = string(res.Path)
+		wall = res.Timings.Total
+	}
 	if err != nil {
 		m.logger.Warn("auto-booking failed",
 			slog.String("user", req.UserID),
+			slog.Int64("request_id", req.ID),
 			slog.String("campsite", pick.CampsiteID),
+			slog.String("path", path),
+			slog.Duration("wall", wall),
 			slog.Any("err", err))
 	} else {
 		oid := ""
@@ -501,12 +528,18 @@ func (m *Manager) attemptHoldAndReport(
 		}
 		m.logger.Info("auto-booking held",
 			slog.String("user", req.UserID),
+			slog.Int64("request_id", req.ID),
 			slog.String("campsite", pick.CampsiteID),
+			slog.String("path", path),
+			slog.Duration("wall", wall),
 			slog.String("order_id", oid))
 	}
 
 	result := formatBookingOutcome(pick, res, err)
-	if _, derr := m.notifier.ChannelMessageSend(channelID, result); derr != nil {
+	channelID := <-channelCh
+	if channelID == "" {
+		m.logger.Warn("no DM channel; skipping booking result message", slog.String("userID", req.UserID))
+	} else if _, derr := m.notifier.ChannelMessageSend(channelID, result); derr != nil {
 		m.logger.Warn("send booking result message failed", slog.Any("err", derr))
 	}
 
@@ -564,10 +597,10 @@ func formatBookingOutcome(pick booker.Pick, res *booker.HoldResult, err error) s
 	if err != nil {
 		if errors.Is(err, booker.ErrHumanVerification) {
 			url := booker.CampsiteBookingURL(pick.CampsiteID, pick.CheckIn, pick.CheckOut)
-			return fmt.Sprintf("⚠️ Recreation.gov requires a human verification step for site **%s**. [Open the site and finish manually](%s).",
-				pick.CampsiteID, url)
+			return appendBookingDiag(fmt.Sprintf("⚠️ Recreation.gov requires a human verification step for site **%s**. [Open the site and finish manually](%s).",
+				pick.CampsiteID, url), res)
 		}
-		return fmt.Sprintf("❌ Couldn't hold site **%s**: %s", pick.CampsiteID, err.Error())
+		return appendBookingDiag(fmt.Sprintf("❌ Couldn't hold site **%s**: %s", pick.CampsiteID, err.Error()), res)
 	}
 	url := ""
 	if res != nil && res.OrderID != "" {
@@ -582,7 +615,31 @@ func formatBookingOutcome(pick booker.Pick, res *booker.HoldResult, err error) s
 	if url != "" {
 		line += " [Finish checkout](" + url + ")"
 	}
-	return line
+	return appendBookingDiag(line, res)
+}
+
+// appendBookingDiag appends a one-line diagnostic showing which Pool path
+// produced this hold + the wall-clock total. Helps the user (and us)
+// notice immediately when the warm-tab fast path didn't kick in — that's
+// the strongest signal that the reconcile loop is misbehaving or the
+// chosen parking campsite was wrong.
+func appendBookingDiag(line string, res *booker.HoldResult) string {
+	if res == nil {
+		return line
+	}
+	pathTag := res.Path.Human()
+	wall := res.Timings.Total
+	if pathTag == "" && wall == 0 {
+		return line
+	}
+	var extras []string
+	if pathTag != "" {
+		extras = append(extras, pathTag)
+	}
+	if wall > 0 {
+		extras = append(extras, "wall "+wall.Round(time.Millisecond).String())
+	}
+	return line + "\n_" + strings.Join(extras, " · ") + "_"
 }
 
 func pluralS(n int) string {

--- a/internal/manager/warmtabs.go
+++ b/internal/manager/warmtabs.go
@@ -16,11 +16,12 @@ import (
 const warmTabReconcileInterval = 30 * time.Second
 
 // runWarmTabReconciler keeps one warm Chrome tab open per active auto-book
-// schniff request. For each active request whose owning user has a warm
-// Pool session, the loop calls Pool.EnsureWarmTabForRequest with a stable
-// campsite_id (chosen via Store.PickParkingCampsite) so the tab is parked
-// on a page where grecaptcha enterprise is already loaded. When a schniff
-// deactivates, its tab is closed.
+// schniff request. Each tab is parked on the schniff's campground overview
+// page (/camping/campgrounds/{id}), where grecaptcha enterprise is loaded
+// — empirically that page accepts hold POSTs for any campsite in the
+// campground, so one tab serves every candidate site without re-navigating.
+//
+// When a schniff deactivates, its tab is closed.
 //
 // Idempotent + crash-safe: every cycle re-derives desired state from the DB
 // and applies it. No in-memory state to drift.
@@ -50,13 +51,12 @@ func (m *Manager) reconcileWarmTabsOnce(ctx context.Context) error {
 		return err
 	}
 
-	// desiredByUser maps userID → requestID → campsite_id we want parked.
+	// desiredByUser maps userID → requestID → campground_id we want parked.
 	// We only consider requests whose owner has a warm pool session; the
 	// rest aren't auto-book candidates.
 	type want struct {
-		requestID  int64
-		campsiteID string
-		provider   string
+		requestID    int64
+		campgroundID string
 	}
 	desiredByUser := map[string][]want{}
 	for _, r := range requests {
@@ -66,20 +66,7 @@ func (m *Manager) reconcileWarmTabsOnce(ctx context.Context) error {
 		if !m.pool.HasUser(r.UserID) {
 			continue
 		}
-		site, perr := m.store.PickParkingCampsite(ctx, r.Provider, r.CampgroundID)
-		if perr != nil {
-			m.logger.Warn("pick parking campsite failed",
-				slog.Int64("request_id", r.ID),
-				slog.String("campground", r.CampgroundID),
-				slog.Any("err", perr))
-			continue
-		}
-		if site == "" {
-			// No campsite metadata for this campground yet — skip until
-			// the next cycle so a fresh schniff doesn't churn.
-			continue
-		}
-		desiredByUser[r.UserID] = append(desiredByUser[r.UserID], want{r.ID, site, r.Provider})
+		desiredByUser[r.UserID] = append(desiredByUser[r.UserID], want{r.ID, r.CampgroundID})
 	}
 
 	// Apply desired set per user; close any extra tabs.
@@ -88,13 +75,13 @@ func (m *Manager) reconcileWarmTabsOnce(ctx context.Context) error {
 		for _, w := range wants {
 			desiredIDs[w.requestID] = struct{}{}
 			ectx, ecancel := context.WithTimeout(ctx, 90*time.Second)
-			err := m.pool.EnsureWarmTabForRequest(ectx, userID, w.requestID, w.campsiteID)
+			err := m.pool.EnsureWarmTabForRequest(ectx, userID, w.requestID, w.campgroundID)
 			ecancel()
 			if err != nil {
 				m.logger.Warn("ensure warm tab failed",
 					slog.String("user_id", userID),
 					slog.Int64("request_id", w.requestID),
-					slog.String("campsite_id", w.campsiteID),
+					slog.String("campground_id", w.campgroundID),
 					slog.Any("err", err))
 				continue
 			}

--- a/internal/manager/warmtabs.go
+++ b/internal/manager/warmtabs.go
@@ -1,0 +1,131 @@
+package manager
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// warmTabReconcileInterval is how often we resync the warm-tab set against
+// the active-schniff set. Tabs open for new schniffs, close for deactivated
+// ones, and refresh if the campground's chosen parking campsite changes.
+//
+// 30s is short enough to bring a freshly-created auto-book schniff to a
+// warm state within one cycle, and long enough that the per-tab Nav (~1s)
+// doesn't constantly recompete with normal poll-cycle DB / chromedp work.
+const warmTabReconcileInterval = 30 * time.Second
+
+// runWarmTabReconciler keeps one warm Chrome tab open per active auto-book
+// schniff request. For each active request whose owning user has a warm
+// Pool session, the loop calls Pool.EnsureWarmTabForRequest with a stable
+// campsite_id (chosen via Store.PickParkingCampsite) so the tab is parked
+// on a page where grecaptcha enterprise is already loaded. When a schniff
+// deactivates, its tab is closed.
+//
+// Idempotent + crash-safe: every cycle re-derives desired state from the DB
+// and applies it. No in-memory state to drift.
+func (m *Manager) runWarmTabReconciler(ctx context.Context) {
+	// Tick immediately on startup so freshly-deployed bots warm up the
+	// existing schniff set without waiting a full interval.
+	if err := m.reconcileWarmTabsOnce(ctx); err != nil {
+		m.logger.Warn("warm tab reconcile: initial run failed", slog.Any("err", err))
+	}
+	t := time.NewTicker(warmTabReconcileInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := m.reconcileWarmTabsOnce(ctx); err != nil {
+				m.logger.Warn("warm tab reconcile failed", slog.Any("err", err))
+			}
+		}
+	}
+}
+
+func (m *Manager) reconcileWarmTabsOnce(ctx context.Context) error {
+	requests, err := m.store.ListActiveRequests(ctx)
+	if err != nil {
+		return err
+	}
+
+	// desiredByUser maps userID → requestID → campsite_id we want parked.
+	// We only consider requests whose owner has a warm pool session; the
+	// rest aren't auto-book candidates.
+	type want struct {
+		requestID  int64
+		campsiteID string
+		provider   string
+	}
+	desiredByUser := map[string][]want{}
+	for _, r := range requests {
+		if !r.Active {
+			continue
+		}
+		if !m.pool.HasUser(r.UserID) {
+			continue
+		}
+		site, perr := m.store.PickParkingCampsite(ctx, r.Provider, r.CampgroundID)
+		if perr != nil {
+			m.logger.Warn("pick parking campsite failed",
+				slog.Int64("request_id", r.ID),
+				slog.String("campground", r.CampgroundID),
+				slog.Any("err", perr))
+			continue
+		}
+		if site == "" {
+			// No campsite metadata for this campground yet — skip until
+			// the next cycle so a fresh schniff doesn't churn.
+			continue
+		}
+		desiredByUser[r.UserID] = append(desiredByUser[r.UserID], want{r.ID, site, r.Provider})
+	}
+
+	// Apply desired set per user; close any extra tabs.
+	for userID, wants := range desiredByUser {
+		desiredIDs := make(map[int64]struct{}, len(wants))
+		for _, w := range wants {
+			desiredIDs[w.requestID] = struct{}{}
+			ectx, ecancel := context.WithTimeout(ctx, 90*time.Second)
+			err := m.pool.EnsureWarmTabForRequest(ectx, userID, w.requestID, w.campsiteID)
+			ecancel()
+			if err != nil {
+				m.logger.Warn("ensure warm tab failed",
+					slog.String("user_id", userID),
+					slog.Int64("request_id", w.requestID),
+					slog.String("campsite_id", w.campsiteID),
+					slog.Any("err", err))
+				continue
+			}
+		}
+		// Close any tabs for requests that are no longer active.
+		for _, existingID := range m.pool.ListRequestTabs(userID) {
+			if _, ok := desiredIDs[existingID]; ok {
+				continue
+			}
+			m.pool.CloseRequestTab(userID, existingID)
+			m.logger.Info("closed warm tab for deactivated request",
+				slog.String("user_id", userID),
+				slog.Int64("request_id", existingID))
+		}
+	}
+
+	// Users with no desired tabs at all: close everything they still hold.
+	for _, r := range requests {
+		if _, seen := desiredByUser[r.UserID]; seen {
+			continue
+		}
+		if !m.pool.HasUser(r.UserID) {
+			continue
+		}
+		for _, existingID := range m.pool.ListRequestTabs(r.UserID) {
+			m.pool.CloseRequestTab(r.UserID, existingID)
+			m.logger.Info("closed warm tab (no active auto-book requests)",
+				slog.String("user_id", r.UserID),
+				slog.Int64("request_id", existingID))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Cuts on-demand booking wall time from **~2.3s → ~1.4s (–40%)** by keeping one Chrome tab open per active auto-book schniff, **parked on the schniff's campground overview page** (`/camping/campgrounds/{id}`). From that tab, HoldFast can book *any* campsite in the campground without ever re-navigating — verified empirically.

- `Pool.EnsureWarmTabForRequest` / `HoldOnRequestTab` / `CloseRequestTab` — dedicated chromedp tab keyed by `(userID, requestID)`, backed by the user's existing Session. Survives across poll cycles, cleaned up on schniff deactivation, session relaunch, or pool teardown.
- Manager `runWarmTabReconciler` (30s ticker, fires on startup): keeps the warm-tab set in sync with active auto-book schniffs. Each tab is parked on the schniff's campground page — no per-campsite choice needed.
- Notification hot path reordered: booking goroutine fires **immediately after `Arbitrate`**, before any Discord call. `UserChannelCreate` is resolved in a sibling goroutine so the chromedp POST no longer waits on Discord (~500ms–1s off critical path).
- Per-phase `booking_phase` slog lines with `correlation_id`, `user_id`, `request_id`, `campsite_id`, `campground_id` so a single booking can be grep'd cleanly out of the firehose. Existing per-phase histograms are kept for aggregates.
- `HoldResult.Path` tags which branch produced the result (`warm_tab_fast` / `main_session` / `relaunch_retry`). The booking outcome DM appends a one-liner showing the path + wall time, and a single `auto_book_path` log line summarises the decision per attempt.
- **Bug fix**: `HoldResult.Timings.Total` was always 0 because the `defer t.Total = ...` ran *after* the value-copy at return, so the existing total histogram observation was silently skipped (`obs("total", t.Total)` saw `d=0` and the guard `if d <= 0 { return }` dropped it). Total is now populated on every return path.

Exploration harnesses under `cmd/booker-{bench,stability,warmtab-test}` + `cmd/recaptcha-probe` so the next person doesn't have to rebuild them. None of them ship to the prod container.

## Why park on the campground page, not a specific campsite?

The earlier version of this PR parked each tab on a specific campsite page (highest-rated for the campground) and had to re-navigate when arbitration picked a different candidate. That re-nav path (`warm_tab_nav`) cost ~1s and felt wrong: if you have one tab per schniff, you should never have to navigate.

Tested empirically with `cmd/recaptcha-probe`: grecaptcha enterprise loads on the campground overview page, the homepage, and search — and `cmd/booker-warmtab-test` confirms that a hold POST minted from the campground page is **accepted by rec.gov with `STATUS=200` and a real `order_id`**. The booking POST URL is keyed by `campgroundID`; the recaptcha token is action-bound (`campsiteListBooking`) not URL-bound. There is no per-campsite binding anywhere in the booking handshake.

So now we park each schniff's tab on `/camping/campgrounds/{campgroundID}` once at warmup and never re-navigate. One tab serves every campsite in the campground for the schniff's lifetime.

The path enum is now just three values:

| Path | When | Wall (typical) |
|---|---|---|
| `warm_tab_fast` | Warm tab exists for this schniff and is parked on the schniff's campground | **~1.4s** |
| `main_session` | No warm tab registered yet (reconcile loop hasn't ticked, or it failed to open). Legacy all-in-one path. | ~2.3–2.7s |
| `relaunch_retry` | The session's JWT silently expired mid-booking; Pool relaunched + retried | ~3–5s |

**Why this stays bounded in memory:** one tab per *active schniff* (not per user, not per campsite). With <10 active auto-book users × maybe 1–3 schniffs each = ≤30 tabs worst case. Chrome is bind-mounted to a 6GB host limit (see compose) — well within budget.

## What this PR doesn't do

- **Doesn't change poll cadence**: still 5s, the rec.gov-429 floor from PR #33. The detection→POST gap remains the 0–5s poll lag + the warm-tab booking (~1.4s).
- **Doesn't pre-mint recaptcha tokens**: the win is only ~220ms and Google's risk engine may score pre-minted tokens lower. Deferred until we have prod data showing the warm-tab change isn't enough.
- **Doesn't change rec.gov's risk gate**: the `abnormal activity` 400 we still get under burst is rec.gov-side, not us.

## Test plan

- [x] `go build ./...` + `go test -short -timeout 60s ./...` green
- [x] `cmd/recaptcha-probe`: confirmed grecaptcha enterprise loads + tokens mint on campground page, homepage, search results
- [x] `cmd/booker-warmtab-test` end-to-end against rec.gov Baker Dam: step 2 holds siteA on warm tab (fast path), step 3 holds **siteB on the SAME warm tab** without re-navigating (also fast path, ~1.8s wall), step 5 fallback main session works (~3.3s). Three real orders returned; all auto-expire in 15 min.
- [ ] Deploy to prod, watch `auto_book_path` + `booking_phase` logs and the existing per-phase histograms for the first auto-book firing
- [ ] Confirm `schniffer_booker_hold_duration_seconds` now has `phase="total"` observations (the bug-fix outcome)
- [ ] Watch for any unexpected `relaunch_retry` rate — high rate suggests the JWT-expiry watchdog needs tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)