### PR TITLE
perf(db): skip no-op upserts, drop dbWriter queue, drop stale index

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -35,7 +35,6 @@ CREATE TABLE IF NOT EXISTS campsite_availability (
 );
 
 CREATE INDEX IF NOT EXISTS idx_availability_lookup ON campsite_availability(provider, campground_id, date);
-CREATE INDEX IF NOT EXISTS idx_availability_stale ON campsite_availability(last_checked);
 CREATE INDEX IF NOT EXISTS idx_availability_available_filtered ON campsite_availability(provider, campground_id, available, date) WHERE available=1;
 CREATE INDEX IF NOT EXISTS idx_availability_date_range ON campsite_availability(provider, campground_id, date, available);
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -91,9 +91,14 @@ func Open(path string) (*Store, error) {
 		return nil, err
 	}
 
-	// Configure write connection for single connection
-	writeDB.SetMaxOpenConns(1)
-	writeDB.SetMaxIdleConns(1)
+	// Configure write connection pool. Multiple writers are fine —
+	// SQLite serializes at the WAL write lock with _busy_timeout=5000
+	// from the DSN, and Go's connection pool reuses each conn safely.
+	// Previously this was MaxOpenConns=1 because callers also went
+	// through a manager-side dbWriter goroutine queue; we deleted that
+	// queue, so this pool size is now the actual concurrency bound.
+	writeDB.SetMaxOpenConns(4)
+	writeDB.SetMaxIdleConns(4)
 	writeDB.SetConnMaxLifetime(0) // No limit for write connection
 
 	// Read-only connection (multiple connections for reads)
@@ -304,6 +309,14 @@ func migrate(db *sql.DB) error {
 				return fmt.Errorf("apply migration %q: %w", alter, aerr)
 			}
 		}
+	}
+	// Idempotent index drops. idx_availability_stale was originally
+	// created for a never-implemented "last verified" query path; the
+	// column it indexes is write-only in the app, so the index is pure
+	// write-amplification cost. Dropping reclaims its disk + checkpoint
+	// budget. DROP INDEX IF EXISTS is a no-op on a fresh DB.
+	if _, err := db.Exec(`DROP INDEX IF EXISTS idx_availability_stale`); err != nil {
+		return fmt.Errorf("drop idx_availability_stale: %w", err)
 	}
 	return nil
 }
@@ -643,13 +656,15 @@ func (s *Store) upsertCampsiteAvailabilityChunk(ctx context.Context, states []Ca
 	}
 	defer tx.Rollback()
 
-	// Fixed temp-table name. The write pool is single-connection
-	// (MaxOpenConns=1) so two upserts never run concurrently on the
-	// same conn, and SQLite TEMP tables are connection-scoped. We DROP
-	// first to clear any leftover from a previously rolled-back tx on
-	// this connection. Using a UUID-suffixed name here previously
-	// generated unbounded `query` label values on the DB query
-	// histogram and OOM-killed Prometheus.
+	// Fixed temp-table name. SQLite TEMP tables are *connection*-scoped,
+	// so concurrent upserts on different write-pool connections each
+	// see their own `temp_new_states` and never collide. Within a
+	// single connection a transaction guarantees the previous use is
+	// fully committed or rolled back before we re-enter — we still DROP
+	// IF EXISTS first to clear any leftover from a rolled-back tx that
+	// committed the CREATE but reverted the DROP. Using a UUID-suffixed
+	// name here previously generated unbounded `query` label values on
+	// the DB query histogram and OOM-killed Prometheus.
 	const tableName = "temp_new_states"
 	if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS temp_new_states;`); err != nil {
 		return fmt.Errorf("drop stale temp table: %w", err)
@@ -705,12 +720,28 @@ func (s *Store) upsertCampsiteAvailabilityChunk(ctx context.Context, states []Ca
 		return fmt.Errorf("insert state_changes from temp table: %w", err)
 	}
 
-	// 4. Upsert into the main availability table.
+	// 4. Upsert into the main availability table — but only rows whose
+	// value differs from what's already there (or that are brand-new).
+	// At ~7000 sites × every-5-second polling, the vast majority of
+	// polls return identical availability for every row; writing those
+	// no-op rows just to refresh last_checked was costing ~80% of the
+	// persist wall time and inflating WAL between checkpoints. The WHERE
+	// clause mirrors step 3's state-change filter, so anything that
+	// generated a state_changes row also gets upserted here, and
+	// anything filtered out here was already a no-op for change
+	// detection. (last_checked therefore only advances on actual value
+	// changes; the column is never read in conditional logic anywhere
+	// in the app, so this is a behaviour-preserving optimization.)
 	sqlUpsert := fmt.Sprintf(`
         INSERT INTO campsite_availability (provider, campground_id, campsite_id, date, available, last_checked)
-        SELECT provider, campground_id, campsite_id, date, available, last_checked
-        FROM %s
-        WHERE true
+        SELECT ns.provider, ns.campground_id, ns.campsite_id, ns.date, ns.available, ns.last_checked
+        FROM %s AS ns
+        LEFT JOIN campsite_availability AS ca
+            ON  ca.provider = ns.provider
+            AND ca.campground_id = ns.campground_id
+            AND ca.campsite_id = ns.campsite_id
+            AND ca.date = ns.date
+        WHERE ca.provider IS NULL OR ca.available != ns.available
         ON CONFLICT (provider, campground_id, campsite_id, date)
         DO UPDATE SET
             available = excluded.available,

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -16,12 +16,6 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-// dbWriteRequest represents a database write operation to be serialized
-type dbWriteRequest struct {
-	operation func() error
-	result    chan error
-}
-
 type Manager struct {
 	store            *db.Store
 	reg              *providers.Registry
@@ -29,7 +23,6 @@ type Manager struct {
 	notifier         *discordgo.Session
 	summaryChannelID string
 	logger           *slog.Logger
-	dbWriteChan      chan dbWriteRequest
 
 	// Optional auto-booking. Nil when SCHNIFFER_ENC_KEY is unset or pool
 	// isn't wired; notification path falls back to plain DM in that case.
@@ -43,43 +36,17 @@ func (m *Manager) SetAutoBooking(pool *booker.Pool) {
 }
 
 func NewManager(store *db.Store, reg *providers.Registry, notifier *discordgo.Session, summaryChannelID string) *Manager {
-	m := &Manager{
+	return &Manager{
 		store:            store,
 		reg:              reg,
 		notifier:         notifier,
 		summaryChannelID: summaryChannelID,
 		logger:           slog.Default(),
-		dbWriteChan:      make(chan dbWriteRequest, 100), // Buffer to prevent blocking
 	}
-	// Start database writer goroutine
-	go m.dbWriter()
-	return m
 }
 
 func (m *Manager) GetSummaryChannel() string {
 	return m.summaryChannelID
-}
-
-// dbWriter processes database write operations sequentially to avoid lock contention
-func (m *Manager) dbWriter() {
-	for req := range m.dbWriteChan {
-		req.result <- req.operation()
-		close(req.result)
-	}
-}
-
-// executeDBOperation queues a database operation for sequential execution
-func (m *Manager) executeDBOperation(operation func() error) error {
-	result := make(chan error, 1)
-	req := dbWriteRequest{
-		operation: operation,
-		result:    result,
-	}
-
-	// This will block and wait if the channel is full,
-	// guaranteeing sequential execution.
-	m.dbWriteChan <- req
-	return <-result
 }
 
 // Run polls providers at dynamic intervals based on their rate limit status
@@ -260,11 +227,9 @@ func (m *Manager) PollProvider(ctx context.Context, targetProvider string) error
 		metrics.PollCycleFailed.WithLabelValues(targetProvider).Add(float64(failedCG))
 	}
 
-	// One batched insert at end of cycle instead of N writes through the writer.
+	// One batched insert at end of cycle.
 	if len(allLookups) > 0 {
-		if err := m.executeDBOperation(func() error {
-			return m.store.RecordLookupBatch(ctx, allLookups)
-		}); err != nil {
+		if err := m.store.RecordLookupBatch(ctx, allLookups); err != nil {
 			m.logger.Warn("record lookup batch failed", slog.Any("err", err))
 		}
 	}
@@ -357,9 +322,7 @@ func (m *Manager) pollOneCampground(ctx context.Context, prov providers.Provider
 		})
 	}
 	start := time.Now()
-	if err := m.executeDBOperation(func() error {
-		return m.store.UpsertCampsiteAvailabilityBatch(ctx, batch)
-	}); err != nil {
+	if err := m.store.UpsertCampsiteAvailabilityBatch(ctx, batch); err != nil {
 		m.logger.Error("upsert states failed", slog.String("provider", k.prov), slog.String("campground", k.cg), slog.Any("err", err))
 	} else {
 		m.logger.Info("persisted campsite states",
@@ -642,12 +605,9 @@ func (m *Manager) processAdhocScrapeRequest(ctx context.Context, req *db.AdhocSc
 		})
 	}
 
-	// Store results in database using the serialized writer
+	// Store results in database.
 	if len(availabilityStates) > 0 {
-		err = m.executeDBOperation(func() error {
-			return m.store.UpsertCampsiteAvailabilityBatch(ctx, availabilityStates)
-		})
-		if err != nil {
+		if err := m.store.UpsertCampsiteAvailabilityBatch(ctx, availabilityStates); err != nil {
 			return fmt.Errorf("failed to store availability results: %w", err)
 		}
 	}

--- a/internal/manager/parallelism_test.go
+++ b/internal/manager/parallelism_test.go
@@ -82,12 +82,10 @@ func TestPollProviderCampgroundsRunConcurrently(t *testing.T) {
 	reg.Register(prov.Name(), prov)
 
 	m := &Manager{
-		store:       store,
-		reg:         reg,
-		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		dbWriteChan: make(chan dbWriteRequest, 100),
+		store:  store,
+		reg:    reg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
-	go m.dbWriter()
 
 	ctx := context.Background()
 	checkin := time.Now().Add(24 * time.Hour).UTC().Truncate(24 * time.Hour)
@@ -156,12 +154,10 @@ func TestPollProviderContinuesPastErrors(t *testing.T) {
 	reg.Register(prov.Name(), prov)
 
 	m := &Manager{
-		store:       store,
-		reg:         reg,
-		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-		dbWriteChan: make(chan dbWriteRequest, 100),
+		store:  store,
+		reg:    reg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
-	go m.dbWriter()
 
 	ctx := context.Background()
 	checkin := time.Now().Add(24 * time.Hour).UTC().Truncate(24 * time.Hour)


### PR DESCRIPTION
## Summary

Three changes targeting the persist hot path you noticed in prod logs (persist span ~160ms across 3 campgrounds; the 200ms tail was on the 7050-row campground):

1. **Skip no-op upserts in `UpsertCampsiteAvailabilityBatch`.** Today every `campsite × date` row is re-upserted every 5s even when the availability flag didn't move — just to refresh `last_checked`. ~7050 sites × 17,280 polls/day = ~122M no-op writes/day per campground. The upsert SQL now LEFT JOINs against the existing row and filters out `(provider IS NOT NULL AND available = excluded.available)` — i.e. only writes new rows and value changes. State-change detection (step 3 of the persist tx) is unchanged; it uses the same WHERE clause shape against the same temp table, so anything that produced a `state_changes` row also produces an upsert here, and anything filtered out here was already a no-op for change detection.

   **Behaviour preservation**: `last_checked` still advances on every actual change. The column is never read in any conditional path in the app (struct field is scanned but unused), so freezing its value for unchanged rows is invisible to all callers.

2. **Drop the Manager-side `dbWriter` goroutine + `dbWriteChan` + `executeDBOperation`.** The queue duplicated what SQLite's WAL + `_busy_timeout=5000` already provide via the connection pool. We were paying a channel send/receive + queue wait for every write with no concurrency benefit (write pool was `MaxOpenConns=1` too).

   Bumped the write connection pool from `MaxOpenConns=1` to `MaxOpenConns=4` so multiple goroutines can have their query phases overlap. SQLite still serializes at the WAL write lock with `_busy_timeout=5000` (DSN-level), so two concurrent commits queue at the storage layer instead of in our Go channel — same serialization, one fewer hop, no manager-side bottleneck.

   The `temp_new_states` table comment updated: it's connection-scoped in SQLite, so concurrent upserts on different write-pool conns each get their own namespace and don't collide.

3. **Drop `idx_availability_stale` via a migration in `migrate()`.** Index existed only to support a "find stale data" query path that was never implemented. With change #1 it would have churned even less, but with neither caller nor write justification it's pure write-amplification cost.

## Expected post-deploy behaviour

- `persisted campsite states` `duration_ms` on no-change polls (the vast majority) should drop from 30–200ms → ~5–15ms (just the temp table create + the JOIN scan, no row writes).
- Notification latency floor on cycles where availability *did* change drops by the persist-span amount (~160ms in the prod 09:23 example).
- Migration runs `DROP INDEX IF EXISTS idx_availability_stale` once on startup; idempotent so no-op on re-runs.

## Test plan

- [x] `go build ./...` + `go test -short -timeout 60s ./...` green
- [x] `gofmt -l internal cmd proxy` clean
- [x] `TestPollProviderCampgroundsRunConcurrently` still passes after dbWriter removal (peak concurrency=20 across 20 campgrounds, ~100ms wall vs 2s serial)
- [ ] Deploy: confirm `persisted campsite states` `duration_ms` drops materially on cycles where nothing changed
- [ ] Confirm `DROP INDEX IF EXISTS idx_availability_stale` runs cleanly on the existing prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)