### PR TITLE
feat(daily-summary): skip nightly roundup on idle days

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -453,6 +453,15 @@ func (m *Manager) fireDailySummary(ctx context.Context) {
 		m.logger.Error("daily summary: get data failed", slog.Any("err", err))
 		return
 	}
+	// Skip the roundup on idle days. "Activity" here means schniffs were
+	// active during the day — either still active now (ActiveRequests) or
+	// scraped at some point in the window (Lookups24h). We deliberately do
+	// NOT require an actual detection/DM, so quiet-but-watching days still
+	// count as activity worth reporting.
+	if summary.Stats.ActiveRequests == 0 && summary.Stats.Lookups24h == 0 {
+		m.logger.Info("daily summary skipped: no activity in the last 24h")
+		return
+	}
 	summary.UserNames = m.resolveUserNames(summary)
 	embed := db.MakeSummaryEmbed(summary)
 	m.logger.Info("daily summary firing",


### PR DESCRIPTION
## What

The daily summary alert now only fires when there was activity that day. If no schniffs were active, the roundup is skipped.

## Why

A nightly roundup with nothing to report is just noise.

## Details

`fireDailySummary` now bails out early when both:
- `ActiveRequests == 0` (nothing currently active), and
- `Lookups24h == 0` (nothing scraped in the 24h window)

"Activity" deliberately does **not** require an actual detection/DM, so quiet-but-watching days still fire. Logs an info line when skipped so the cron job isn't silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)